### PR TITLE
Enable --allow-multiple-documents in check-yaml of pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         files: (.*\.(py|md|rst|yaml|yml|json|ts|js|html|svelte|sh))$
       - id: check-json
       - id: check-yaml
+        args: [--allow-multiple-documents]
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: trailing-whitespace


### PR DESCRIPTION
## Type of Change

Enable --allow-multiple-documents in check-yaml of pre-commit-config

## Description

Enable --allow-multiple-documents in check-yaml of pre-commit-config because K8s manifest yaml files allows multiple documents.