### PR TITLE
remove check-yaml and prettier from pre-commit-config for yaml checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,6 @@ repos:
       - id: end-of-file-fixer
         files: (.*\.(py|md|rst|yaml|yml|json|ts|js|html|svelte|sh))$
       - id: check-json
-      - id: check-yaml
-        args: [--allow-multiple-documents]
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: trailing-whitespace
@@ -77,7 +75,7 @@ repos:
     hooks:
       - id: prettier
         args: [--print-width=120]
-        types_or: [yaml, markdown, html, css, scss, javascript, json, ts, shell, sh]
+        types_or: [markdown, html, css, scss, javascript, json, ts, shell, sh]
         additional_dependencies:
           - prettier@3.2.5
 


### PR DESCRIPTION
## Type of Change

remove check-yaml and prettier from pre-commit-config for yaml checking 

## Description

Helm charts yamls have many special formats to support K8s deployment. Those cannot pass check-yaml defined in pre-commit-config. What's more, the `prettier` will format our charts yaml files which makes helm charts invalid. So we have to remove yaml checking from pre-commit-config. We will use helm charts validation CI to check helm charts yaml format. 