### PR TITLE
Helm chart for CodeGen on Xeon

### DIFF
--- a/helm-charts/codegen/.helmignore
+++ b/helm-charts/codegen/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/codegen/Chart.yaml
+++ b/helm-charts/codegen/Chart.yaml
@@ -1,0 +1,12 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: codegen
+description: The Helm chart to deploy CodeGen
+type: application
+dependencies:
+  - name: tgi
+    version: "0.1.0"
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -1,0 +1,28 @@
+# CodeGen
+
+Helm chart for deploying CodeGen service.
+
+CodeGen depends on tgi, refer to tgi for more config details.
+
+## Installing the Chart
+
+To install the chart, run the following:
+
+```console
+$ export HFTOKEN="insert-your-huggingface-token-here"
+$ export MODELDIR="/mnt"
+$ export MODELNAME="m-a-p/OpenCodeInterpreter-DS-6.7B"
+$ helm install codegen codegen --set hfToken=${HFTOKEN} --set tgi.hftgi.volume=${MODELDIR} --set tgi.hftgi.modelId=${MODELNAME}
+```
+
+## Values
+
+| Key               | Type   | Default                               | Description                                                                                                                              |
+| ----------------- | ------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| hfToken           | string | `""`                                  | Your own Hugging Face API token                                                                                                          |
+| image.repository  | string | `"intel/gen-ai-examples"`             |                                                                                                                                          |
+| image.tag         | string | `"copilot"`                           |                                                                                                                                          |
+| service.port      | string | `"80"`                                |                                                                                                                                          |
+| tgi.hftgi.modelId | string | `"m-a-p/OpenCodeInterpreter-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
+| tgi.hftgi.port    | string | `"80"`                                | Hugging Face Text Generation Inference service port                                                                                      |
+| tgi.hftgi.volume  | string | `"/mnt"`                              | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |

--- a/helm-charts/codegen/charts/tgi/.helmignore
+++ b/helm-charts/codegen/charts/tgi/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/codegen/charts/tgi/Chart.yaml
+++ b/helm-charts/codegen/charts/tgi/Chart.yaml
@@ -1,0 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: tgi
+description: The Helm chart for HuggingFace Text Generation Inference Server
+type: application
+version: 0.1.0
+# The HF TGI version
+appVersion: "1.4"

--- a/helm-charts/codegen/charts/tgi/README.md
+++ b/helm-charts/codegen/charts/tgi/README.md
@@ -1,0 +1,32 @@
+# tgi
+
+Helm chart for deploying Hugging Face Text Generation Inference service.
+
+## Installing the Chart
+
+To install the chart, run the following:
+
+```console
+$ export MODELDIR=/mnt
+$ export MODELNAME="bigscience/bloom-560m"
+$ helm install tgi tgi --set hftgi.volume=${MODELDIR} --set hftgi.modelId=${MODELNAME}
+```
+
+By default, the tgi service will downloading the "bigscience/bloom-560m" which is about 1.1GB.
+
+If you already cached the model locally, you can pass it to container like this example:
+
+MODELDIR=/home/ubuntu/hfmodels
+
+MODELNAME="/data/models--bigscience--bloom-560m"
+
+## Values
+
+| Key           | Type   | Default                                           | Description                                                                                                                              |
+| ------------- | ------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| hftgi.modelId | string | `"bigscience/bloom-560m"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
+| hftgi.port    | string | `"80"`                                            | Hugging Face Text Generation Inference service port                                                                                      |
+| hftgi.volume  | string | `"/mnt"`                                          | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
+| hftgi.image   | string | `"ghcr.io/huggingface/text-generation-inference"` |                                                                                                                                          |
+| hftgi.tag     | string | `"1.4"`                                           |                                                                                                                                          |
+| service.port  | string | `"80"`                                            | The service port                                                                                                                         |

--- a/helm-charts/codegen/charts/tgi/templates/NOTES.txt
+++ b/helm-charts/codegen/charts/tgi/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "tgi.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "tgi.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "tgi.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "tgi.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm-charts/codegen/charts/tgi/templates/_helpers.tpl
+++ b/helm-charts/codegen/charts/tgi/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tgi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tgi.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tgi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tgi.labels" -}}
+helm.sh/chart: {{ include "tgi.chart" . }}
+{{ include "tgi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tgi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tgi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tgi.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tgi.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/codegen/charts/tgi/templates/deployment.yaml
+++ b/helm-charts/codegen/charts/tgi/templates/deployment.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tgi.fullname" . }}
+  labels:
+    {{- include "tgi.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tgi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tgi.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: MODEL_ID
+              value: {{ .Values.HFTGI.MODEL_ID }}
+            - name: PORT
+              value: {{ .Values.HFTGI.Port | quote }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+                #          livenessProbe:
+                #            httpGet:
+                #              path: /
+                #              port: http
+                #          readinessProbe:
+                #            httpGet:
+                #              path: /
+                #              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+            #          command:
+            #            - "/usr/bin/bash"
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: {{ .Values.HFTGI.Volume }}
+            type: Directory
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/codegen/charts/tgi/templates/deployment.yaml
+++ b/helm-charts/codegen/charts/tgi/templates/deployment.yaml
@@ -31,9 +31,9 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             - name: MODEL_ID
-              value: {{ .Values.HFTGI.MODEL_ID }}
+              value: {{ .Values.hftgi.modelId }}
             - name: PORT
-              value: {{ .Values.HFTGI.Port | quote }}
+              value: {{ .Values.hftgi.port | quote }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -45,14 +45,24 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-                #          livenessProbe:
-                #            httpGet:
-                #              path: /
-                #              port: http
-                #          readinessProbe:
-                #            httpGet:
-                #              path: /
-                #              port: http
+#          livenessProbe:
+#            httpGet:
+#              path: /
+#              port: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            failureThreshold: 20
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
             #          command:
@@ -60,7 +70,7 @@ spec:
       volumes:
         - name: model-volume
           hostPath:
-            path: {{ .Values.HFTGI.Volume }}
+            path: {{ .Values.hftgi.volume }}
             type: Directory
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-charts/codegen/charts/tgi/templates/service.yaml
+++ b/helm-charts/codegen/charts/tgi/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.HFTGI.Port }}
+      targetPort: {{ .Values.hftgi.port }}
       protocol: TCP
       name: tgi
   selector:

--- a/helm-charts/codegen/charts/tgi/templates/service.yaml
+++ b/helm-charts/codegen/charts/tgi/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tgi.fullname" . }}
+  labels:
+    {{- include "tgi.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.HFTGI.Port }}
+      protocol: TCP
+      name: tgi
+  selector:
+    {{- include "tgi.selectorLabels" . | nindent 4 }}

--- a/helm-charts/codegen/charts/tgi/values.yaml
+++ b/helm-charts/codegen/charts/tgi/values.yaml
@@ -1,17 +1,17 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Default values for docsum.
+# Default values for tgi.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
 
-HFTGI:
-  MODEL_ID: m-a-p/OpenCodeInterpreter-DS-6.7B
-  #MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
-  Port: 80
-  Volume: /home/ubuntu/models
+hftgi:
+  modelId: bigscience/bloom-560m
+  # modelId: /data/OpenCodeInterpreter-DS-6.7B
+  port: 80
+  volume: /mnt
 
 image:
   repository: ghcr.io/huggingface/text-generation-inference

--- a/helm-charts/codegen/charts/tgi/values.yaml
+++ b/helm-charts/codegen/charts/tgi/values.yaml
@@ -1,0 +1,59 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for docsum.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+HFTGI:
+  MODEL_ID: m-a-p/OpenCodeInterpreter-DS-6.7B
+  #MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
+  Port: 80
+  Volume: /home/ubuntu/models
+
+image:
+  repository: ghcr.io/huggingface/text-generation-inference
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "1.4"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm-charts/codegen/templates/NOTES.txt
+++ b/helm-charts/codegen/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "codegen.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "codegen.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "codegen.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "codegen.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm-charts/codegen/templates/_helpers.tpl
+++ b/helm-charts/codegen/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "codegen.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "codegen.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "codegen.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "codegen.labels" -}}
+helm.sh/chart: {{ include "codegen.chart" . }}
+{{ include "codegen.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "codegen.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "codegen.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "codegen.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "codegen.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/codegen/templates/deployment.yaml
+++ b/helm-charts/codegen/templates/deployment.yaml
@@ -1,0 +1,68 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "codegen.fullname" . }}
+  labels:
+    {{- include "codegen.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "codegen.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "codegen.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          env:
+            - name: TGI_ENDPOINT
+              value: "http://{{ .Release.Name }}-tgi"
+            - name: HUGGINGFACEHUB_API_TOKEN
+              value: {{ .Values.hf_token | quote}}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/usr/local/bin/python"]
+          args: ["server.py"]
+          ports:
+            - name: codegen
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8000
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/codegen/templates/deployment.yaml
+++ b/helm-charts/codegen/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - name: TGI_ENDPOINT
               value: "http://{{ .Release.Name }}-tgi"
             - name: HUGGINGFACEHUB_API_TOKEN
-              value: {{ .Values.hf_token | quote}}
+              value: {{ .Values.hfToken | quote}}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -44,6 +44,14 @@ spec:
             - name: codegen
               containerPort: 8000
               protocol: TCP
+          startupProbe:
+            exec:
+              command:
+              - curl
+              - http://{{ .Chart.Name }}-tgi
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 120
           livenessProbe:
             httpGet:
               path: /

--- a/helm-charts/codegen/templates/service.yaml
+++ b/helm-charts/codegen/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "codegen.fullname" . }}
+  labels:
+    {{- include "codegen.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: codegen
+  selector:
+    {{- include "codegen.selectorLabels" . | nindent 4 }}

--- a/helm-charts/codegen/templates/tests/test-connection.yaml
+++ b/helm-charts/codegen/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "codegen.fullname" . }}-test-connection"
+  labels:
+    {{- include "codegen.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "codegen.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -6,8 +6,8 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
-tgi_endpoint: "http://automaticallydetected"
-hf_token: "yourowntokenfromhuggingface"
+hfToken: "insert-your-huggingface-token-here"
+# tgiEndpoint: "http://automaticallydetected"
 
 image:
   repository: intel/gen-ai-examples
@@ -21,11 +21,11 @@ service:
 
 # To override values in subchart tgi
 tgi:
-  HFTGI:
-    MODEL_ID: m-a-p/OpenCodeInterpreter-DS-6.7B
-    # MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
-    Port: 80
-    Volume: /home/ubuntu/models
+  hftgi:
+    modelId: m-a-p/OpenCodeInterpreter-DS-6.7B
+    # modelId: /data/OpenCodeInterpreter-DS-6.7B
+    port: 80
+    Volume: /mnt
 
   image:
     repository: ghcr.io/huggingface/text-generation-inference

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -1,0 +1,34 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for codegen.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+tgi_endpoint: "http://automaticallydetected"
+hf_token: "yourowntokenfromhuggingface"
+
+image:
+  repository: intel/gen-ai-examples
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "copilot"
+
+service:
+  type: ClusterIP
+  port: 80
+
+# To override values in subchart tgi
+tgi:
+  HFTGI:
+    MODEL_ID: m-a-p/OpenCodeInterpreter-DS-6.7B
+    # MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
+    Port: 80
+    Volume: /home/ubuntu/models
+
+  image:
+    repository: ghcr.io/huggingface/text-generation-inference
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "1.4"


### PR DESCRIPTION
Two services in total, the codegen service is depending on tgi. Current tgi supports CPU only, will add Gaudi support later. You'll need a HuggingFace token in values.yaml
hf_token: "yourowntokenfromhuggingface"
Use "helm install codegen codegen" to deploy.

## Type of Change

feature

## Description

Add CodeGen helm charts for Xeon

## How has this PR been tested?
1. Modify the values.yaml hf_token with your huggingface API token
2.  helm install codegen codegen
3. curl http://test-codegen/v1/code_generation -X POST -H "Content-Type: application/json" -d '{"prompt": "def print_hello_world():", "max_new_tokens": 128, "stream": true}'
