### PR TITLE
helm-charts: Add proxy for codegen

### DIFF
--- a/helm-charts/codegen/charts/llm-uservice/charts/tgi/templates/deployment.yaml
+++ b/helm-charts/codegen/charts/llm-uservice/charts/tgi/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
               value: {{ .Values.LLM_MODEL_ID }}
             - name: PORT
               value: {{ .Values.port | quote }}
+            - name: HTTP_PROXY
+              value: {{ .Values.global.http_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.global.https_proxy }}
+            - name: NO_PROXY
+              value: {{ .Values.global.no_proxy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -30,3 +30,8 @@ llm-uservice:
     LLM_MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
     # LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
     volume: /mnt
+
+global:
+  http_proxy:
+  https_proxy:
+  no_proxy:


### PR DESCRIPTION
Allow user to run codegen with proxy settings.

## Description

This is to allow users to run codegen with proxy settings.

## Issues

fix #79 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

N/A
