### PR TITLE
Change env OPEA_IMAGE_REPO to get consistent in xeon and gaudi CI test env

### DIFF
--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -9,7 +9,7 @@ on:
     types: [opened, reopened, ready_for_review, synchronize] # added `ready_for_review` since draft is skipped
     paths:
       - microservices-connector/**
-      - manifests/**
+      - manifests/ChatQnA/**
   workflow_dispatch:
 
 # If there is a new commit, the previous jobs will be canceled
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "SYSTEM_NAMESPACE=opea-system-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "APP_NAMESPACE=chatqna-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
-          echo "DOCKER_REGISTRY=$OPEA_IMAGE_REPO/opea" >> $GITHUB_ENV
+          echo "DOCKER_REGISTRY=${OPEA_IMAGE_REPO}opea" >> $GITHUB_ENV
           echo "VERSION=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "should_cleanup=false" >> $GITHUB_ENV
           echo "skip_validate=false" >> $GITHUB_ENV

--- a/.github/workflows/scripts/e2e/chart_test.sh
+++ b/.github/workflows/scripts/e2e/chart_test.sh
@@ -6,11 +6,11 @@ LOG_PATH=.
 USER_ID=$(whoami)
 CHART_MOUNT=/home/$USER_ID/charts-mnt
 # IMAGE_REPO is $OPEA_IMAGE_REPO, or else ""
-IMAGE_REPO=${OPEA_IMAGE_REPO:-docker.io}
+IMAGE_REPO=${OPEA_IMAGE_REPO:-""}
 
 function init_codegen() {
     # insert a prefix before opea/.*, the prefix is IMAGE_REPO
-    sed -i "s#repository: opea/*#repository: $IMAGE_REPO/opea/#g" values.yaml
+    sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" values.yaml
     # set huggingface token
     sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" values.yaml
     # replace the mount dir "Volume: *" with "Volume: $CHART_MOUNT"
@@ -20,8 +20,8 @@ function init_codegen() {
 function init_chatqna() {
     # replace volume: /mnt with volume: $CHART_MOUNT
     find .. -name '*values.yaml' -type f -exec sed -i "s#volume: /mnt#volume: $CHART_MOUNT#g" {} \;
-    # replace the repository "image: opea/*" with "image: $IMAGE_REPO/opea/"
-    find .. -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: $IMAGE_REPO/opea/#g" {} \;
+    # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
+    find .. -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find .. -name '*values.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
 }

--- a/.github/workflows/scripts/e2e/gmc_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_test.sh
@@ -6,7 +6,7 @@ set -xe
 USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
 MOUNT_DIR=/home/$USER_ID/charts-mnt
-IMAGE_REPO=${OPEA_IMAGE_REPO:-docker.io}
+IMAGE_REPO=${OPEA_IMAGE_REPO:-""}
 
 function install_gmc() {
     # Make sure you have to use image tag $VERSION for microservice-connector installation
@@ -112,8 +112,8 @@ function init_gmc() {
     sed -i "s|name: system|name: $SYSTEM_NAMESPACE|g" $(pwd)/config/rbac/gmc-manager-rbac.yaml
     # replace the mount dir "path: /mnt/model" with "path: $CHART_MOUNT"
     find . -name '*.yaml' -type f -exec sed -i "s#path: /mnt/models#path: $MOUNT_DIR#g" {} \;
-    # replace the repository "image: opea/*" with "image: $IMAGE_REPO/opea/"
-    find . -name '*.yaml' -type f -exec sed -i "s#image: opea/*#image: $IMAGE_REPO/opea/#g" {} \;
+    # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
+    find . -name '*.yaml' -type f -exec sed -i "s#image: opea/*#image: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     # find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
     find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;

--- a/.github/workflows/scripts/e2e/manifest_test.sh
+++ b/.github/workflows/scripts/e2e/manifest_test.sh
@@ -7,14 +7,14 @@ USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
 MOUNT_DIR=/home/$USER_ID/charts-mnt
 # IMAGE_REPO is $OPEA_IMAGE_REPO, or else ""
-IMAGE_REPO=${OPEA_IMAGE_REPO:-docker.io}
+IMAGE_REPO=${OPEA_IMAGE_REPO:-""}
 
 function init_codetrans() {
     # executed under path manifest/codetrans/xeon
     # replace the mount dir "path: /mnt/model" with "path: $CHART_MOUNT"
     find . -name '*.yaml' -type f -exec sed -i "s#path: /mnt#path: $MOUNT_DIR#g" {} \;
-    # replace the repository "image: opea/*" with "image: $IMAGE_REPO/opea/"
-    find . -name '*.yaml' -type f -exec sed -i "s#image: \"opea/*#image: \"$IMAGE_REPO/opea/#g" {} \;
+    # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
+    find . -name '*.yaml' -type f -exec sed -i "s#image: \"opea/*#image: \"${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
 }
@@ -23,8 +23,8 @@ function init_codegen() {
     # executed under path manifest/codegen/xeon
     # replace the mount dir "path: /mnt/model" with "path: $CHART_MOUNT"
     find . -name '*.yaml' -type f -exec sed -i "s#path: /mnt#path: $MOUNT_DIR#g" {} \;
-    # replace the repository "image: opea/*" with "image: $IMAGE_REPO/opea/"
-    find . -name '*.yaml' -type f -exec sed -i "s#image: \"opea/*#image: \"$IMAGE_REPO/opea/#g" {} \;
+    # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
+    find . -name '*.yaml' -type f -exec sed -i "s#image: \"opea/*#image: \"${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
 }
@@ -43,8 +43,8 @@ function init_chatqna() {
     # executed under path manifest/chatqna/xeon
     # replace the mount dir "path: /mnt" with "path: $CHART_MOUNT"
     find . -name '*.yaml' -type f -exec sed -i "s#path: /mnt/models#path: $MOUNT_DIR#g" {} \;
-    # replace the repository "image: opea/*" with "image: $IMAGE_REPO/opea/"
-    find . -name '*.yaml' -type f -exec sed -i "s#image: opea/*#image: $IMAGE_REPO/opea/#g" {} \;
+    # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
+    find . -name '*.yaml' -type f -exec sed -i "s#image: opea/*#image: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
 }


### PR DESCRIPTION
## Description

Change env OPEA_IMAGE_REPO to get consistent in xeon and gaudi CI test env.

## Issues

In Gaudi test env, `$OPEA_IMAGE_REPO` is `<ip>:5000/`. In Xeon test env, `$OPEA_IMAGE_REPO` doesn't with `/`. In order to support both tests in Xeon and Gaudi, we have to keep them consistent.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

CI Test
