### PR TITLE
Add the example of ChatQnA on gaudi node

### DIFF
--- a/microservices-connector/config/samples/chatQnA_gaudi.yaml
+++ b/microservices-connector/config/samples/chatQnA_gaudi.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: gmconnector
     app.kubernetes.io/managed-by: kustomize
-    gmc/platform: xeon
+    gmc/platform: gaudi
   name: chatqa
-  namespace: chatqa
+  namespace: chatqa-gaudi
 spec:
   routerConfig:
     name: router
@@ -23,9 +23,9 @@ spec:
           serviceName: embedding-svc
           config:
             endpoint: /v1/embeddings
-      - name: TeiEmbedding
+      - name: TeiEmbeddingGaudi
         internalService:
-          serviceName: tei-embedding-svc
+          serviceName: tei-embedding-gaudi-svc
           isDownstreamService: true
       - name: Retriever
         data: $response
@@ -55,9 +55,9 @@ spec:
           serviceName: llm-svc
           config:
             endpoint: /v1/chat/completions
-      - name: Tgi
+      - name: TgiGaudi
         internalService:
-          serviceName: tgi-service-m
+          serviceName: tgi-gaudi-svc
           config:
             endpoint: /generate
           isDownstreamService: true

--- a/microservices-connector/internal/controller/gmconnector_controller.go
+++ b/microservices-connector/internal/controller/gmconnector_controller.go
@@ -65,6 +65,7 @@ const (
 	Service                          = "Service"
 	Deployment                       = "Deployment"
 	dplymtSubfix                     = "-deployment"
+	METADATA_PLATFORM                = "gmc/platform"
 )
 
 // GMConnectorReconciler reconciles a GMConnector object
@@ -270,7 +271,12 @@ func (r *GMConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// r.Log.Info("Reconciling connector graph", "apiVersion", graph.APIVersion, "graph", graph.Name)
 	fmt.Println("Reconciling connector graph", "apiVersion", graph.APIVersion, "graph", graph.Name)
 
-	err := preProcessUserConfigmap(ctx, r.Client, req.NamespacedName.Namespace, xeon, graph)
+	platform := xeon
+	if labelValue, exists := graph.GetLabels()[METADATA_PLATFORM]; exists {
+		platform = labelValue
+	}
+
+	err := preProcessUserConfigmap(ctx, r.Client, req.NamespacedName.Namespace, platform, graph)
 	if err != nil {
 		return reconcile.Result{Requeue: true}, errors.Wrapf(err, "Failed to pre-process the Configmap file for xeon")
 	}


### PR DESCRIPTION
## Description

It's okay now for example of ChatQnA on both xeon and gaudi platform, and I also add the platform switcher on matedata label with label `gmc/platform`. `Test` section contains the deployment snapshots.

Moreover, I also validate the example by sending validated requests for them. 

## Issues

https://github.com/opea-project/GenAIInfra/issues/118

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`

## Tests
![image](https://github.com/opea-project/GenAIInfra/assets/4101246/27bc54bf-2b17-4f35-89cc-17ab993aa4cf)



**Xeon version:**

```
$ curl http://router-service.chatqa.svc.cluster.local:8080  \
>   -X POST \
>   -d '{"text":"What is the revenue of Nike in 2023?"}' \
>   -H 'Content-Type: application/json'
data: <br/>

data: An

data: swer

data: :

data: @#$In

data: @#$fiscal

data: @#$

data: 2

data: 0

data: 2

data: 3

data: ,

data: @#$N

data: I

data: KE

data: ,

data: @#$Inc

data: .

data: @#$achieved

data: @#$record

data: @#$Rev

data: en

data: ues

data: @#$of

data: @#$$

data: 5

data: 1

data: .

data: 2

data: @#$billion

data: .

data: [DONE]
```

**Gaudi version:**

```
$ curl http://router-service.chatqa-gaudi.svc.cluster.local:8080  \
>   -X POST \
>   -d '{"text":"What is the revenue of Nike in 2023?"}' \
>   -H 'Content-Type: application/json'
data: <br/>

data: An

data: swer

data: :

data: @#$In

data: @#$fiscal

data: @#$

data: 2

data: 0

data: 2

data: 3

data: ,

data: @#$N

data: I

data: KE

data: ,

data: @#$Inc

data: .

data: @#$achieved

data: @#$record

data: @#$Rev

data: en

data: ues

data: @#$of

data: @#$$

data: 5

data: 1

data: .

data: 2

data: @#$billion

data: .

data: [DONE]
```