### PR TITLE
Fix a small bug in gmc e2e test

### DIFF
--- a/.github/workflows/scripts/e2e/gmc_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_test.sh
@@ -44,10 +44,16 @@ function validate_gmc() {
 
 function cleanup_gmc() {
     echo "clean up microservice-connector"
-    kubectl delete ns $APP_NAMESPACE
-    kubectl delete ns $CODEGEN_NAMESPACE
-    kubectl delete ns $CODETRANS_NAMESPACE
-    kubectl delete ns $SYSTEM_NAMESPACE
+    namespaces=("$APP_NAMESPACE" "$CODEGEN_NAMESPACE" "$CODETRANS_NAMESPACE" "$SYSTEM_NAMESPACE")
+    for ns in "${namespaces[@]}"; do
+        kubectl get namespace "$ns" &> /dev/null
+        if [ $? -eq 0 ]; then
+            echo "Deleting namespace: $ns"
+            kubectl delete namespace "$ns"
+        else
+            echo "Namespace $ns does not exist"
+        fi
+    done
     kubectl delete crd gmconnectors.gmc.opea.io
 }
 


### PR DESCRIPTION
## Description

Fix a small bug in gmc e2e test.

If GMC meets with error during e2e tests, some namespace will not be created. Then the cleanup function will exist with error when deleting the not existed namespace, which will make the opea-system namespace remained in CI server.

## Issues

closes issue #127 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

CI test
