### PR TITLE
Helm chart: Add default minimal pod security

### DIFF
--- a/.github/workflows/scripts/e2e/chart_test.sh
+++ b/.github/workflows/scripts/e2e/chart_test.sh
@@ -10,24 +10,24 @@ IMAGE_REPO=${OPEA_IMAGE_REPO:-""}
 
 function init_codegen() {
     # insert a prefix before opea/.*, the prefix is IMAGE_REPO
-    find . -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
+    find .. -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find . -name '*values.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
     # replace the mount dir "Volume: *" with "Volume: $CHART_MOUNT"
     find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: .*#modelUseHostPath: $CHART_MOUNT#g" {} \;
     # replace the pull policy "IfNotPresent" with "Always"
-    find . -name '*values.yaml' -type f -exec sed -i "s#pullPolicy: IfNotPresent#pullPolicy: Always#g" {} \;
+    find .. -name '*values.yaml' -type f -exec sed -i "s#pullPolicy: IfNotPresent#pullPolicy: Always#g" {} \;
 }
 
 function init_chatqna() {
     # replace volume: /mnt with volume: $CHART_MOUNT
     find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: /mnt#modelUseHostPath: $CHART_MOUNT#g" {} \;
     # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
-    find . -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
+    find .. -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
     find . -name '*values.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
     # replace the pull policy "IfNotPresent" with "Always"
-    find . -name '*values.yaml' -type f -exec sed -i "s#pullPolicy: IfNotPresent#pullPolicy: Always#g" {} \;
+    find .. -name '*values.yaml' -type f -exec sed -i "s#pullPolicy: IfNotPresent#pullPolicy: Always#g" {} \;
 }
 
 function validate_codegen() {

--- a/.github/workflows/scripts/e2e/chart_test.sh
+++ b/.github/workflows/scripts/e2e/chart_test.sh
@@ -14,14 +14,14 @@ function init_codegen() {
     # set huggingface token
     find . -name '*values.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat /home/$USER_ID/.cache/huggingface/token)#g" {} \;
     # replace the mount dir "Volume: *" with "Volume: $CHART_MOUNT"
-    find . -name '*values.yaml' -type f -exec sed -i "s#volume: .*#volume: $CHART_MOUNT#g" {} \;
+    find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: .*#modelUseHostPath: $CHART_MOUNT#g" {} \;
     # replace the pull policy "IfNotPresent" with "Always"
     find . -name '*values.yaml' -type f -exec sed -i "s#pullPolicy: IfNotPresent#pullPolicy: Always#g" {} \;
 }
 
 function init_chatqna() {
     # replace volume: /mnt with volume: $CHART_MOUNT
-    find . -name '*values.yaml' -type f -exec sed -i "s#volume: /mnt#volume: $CHART_MOUNT#g" {} \;
+    find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: /mnt#modelUseHostPath: $CHART_MOUNT#g" {} \;
     # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
     find . -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token

--- a/helm-charts/chatqna/README.md
+++ b/helm-charts/chatqna/README.md
@@ -13,17 +13,17 @@ helm dependency update chatqna
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt"
 export MODELNAME="Intel/neural-chat-7b-v3-3"
-helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.volume=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
+helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
 # To use Gaudi device
 # helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --values chatqna/gaudi-values.yaml
 ```
 
 ## Values
 
-| Key                             | Type   | Default                       | Description                                                                                                                              |
-| ------------------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| image.repository                | string | `"opea/chatqna:latest"`       |                                                                                                                                          |
-| service.port                    | string | `"8888"`                      |                                                                                                                                          |
-| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                          | Your own Hugging Face API token                                                                                                          |
-| global.volume                   | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| llm-uservice.tgi.LLM_MODEL_ID   | string | `"Intel/neural-chat-7b-v3-3"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
+| Key                             | Type   | Default                       | Description                                                                                                                                        |
+| ------------------------------- | ------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| image.repository                | string | `"opea/chatqna:latest"`       |                                                                                                                                                    |
+| service.port                    | string | `"8888"`                      |                                                                                                                                                    |
+| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                          | Your own Hugging Face API token                                                                                                                    |
+| global.modelUseHostPath         | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "volume" will be mounted to container as /data directory |
+| llm-uservice.tgi.LLM_MODEL_ID   | string | `"Intel/neural-chat-7b-v3-3"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                           |

--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -18,6 +18,16 @@ service:
   type: ClusterIP
   port: 8888
 
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 # To override values in subchart llm-uservice
 llm-uservice:
 # To override values in subchart tgi
@@ -30,11 +40,14 @@ llm-uservice:
     resources:
       limits:
         habana.ai/gaudi: 1
+
 global:
   http_proxy:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -18,6 +18,16 @@ service:
   type: ClusterIP
   port: 8888
 
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 # To override values in subchart llm-uservice
 llm-uservice:
 # To override values in subchart tgi
@@ -30,6 +40,8 @@ global:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -15,17 +15,17 @@ helm dependency update codegen
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt"
 export MODELNAME="m-a-p/OpenCodeInterpreter-DS-6.7B"
-helm install codegen codegen --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.volume=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
+helm install codegen codegen --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
 # To use Gaudi device
 # helm install codegen codegen --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --values codegen/gaudi-values.yaml
 ```
 
 ## Values
 
-| Key                             | Type   | Default                          | Description                                                                                                                              |
-| ------------------------------- | ------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| image.repository                | string | `"opea/codegen:latest"`          |                                                                                                                                          |
-| service.port                    | string | `"7778"`                         |                                                                                                                                          |
-| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                             | Your own Hugging Face API token                                                                                                          |
-| global.volume                   | string | `"/mnt"`                         | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| llm-uservice.tgi.LLM_MODEL_ID   | string | `"ise-uiuc/Magicoder-S-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
+| Key                             | Type   | Default                          | Description                                                                                                                                                  |
+| ------------------------------- | ------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| image.repository                | string | `"opea/codegen:latest"`          |                                                                                                                                                              |
+| service.port                    | string | `"7778"`                         |                                                                                                                                                              |
+| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                             | Your own Hugging Face API token                                                                                                                              |
+| global.modelUseHostPath         | string | `"/mnt"`                         | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| llm-uservice.tgi.LLM_MODEL_ID   | string | `"ise-uiuc/Magicoder-S-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |

--- a/helm-charts/codegen/gaudi-values.yaml
+++ b/helm-charts/codegen/gaudi-values.yaml
@@ -18,6 +18,16 @@ service:
   type: ClusterIP
   port: 7778
 
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 # To override values in subchart llm-uservice
 llm-uservice:
   image:
@@ -28,18 +38,20 @@ llm-uservice:
   tgi:
     LLM_MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
     # LLM_MODEL_ID: /data/Magicoder-S-DS-6.7B
-    volume: /mnt
     image:
       repository: ghcr.io/huggingface/tgi-gaudi
       tag: "1.2.1"
     resources:
       limits:
         habana.ai/gaudi: 1
+
 global:
   http_proxy:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -18,6 +18,16 @@ service:
   type: ClusterIP
   port: 7778
 
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 # To override values in subchart llm-uservice
 llm-uservice:
   image:
@@ -34,6 +44,8 @@ global:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/embedding-usvc/README.md
+++ b/helm-charts/common/embedding-usvc/README.md
@@ -11,14 +11,14 @@ To install the chart, run the following:
 ```console
 $ export MODELDIR="/mnt"
 $ export MODELNAME="BAAI/bge-base-en-v1.5"
-$ helm install embedding embedding-usvc --set global.volume=${MODELDIR} --set tei.EMBEDDING_MODEL_ID=${MODELNAME}
+$ helm install embedding embedding-usvc --set global.modelUseHostPath=${MODELDIR} --set tei.EMBEDDING_MODEL_ID=${MODELNAME}
 ```
 
 ## Values
 
-| Key                    | Type   | Default                       | Description                                                                                                                              |
-| ---------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| image.repository       | string | `"opea/embedding-tei:latest"` |                                                                                                                                          |
-| service.port           | string | `"6000"`                      |                                                                                                                                          |
-| tei.EMBEDDING_MODEL_ID | string | `"BAAI/bge-base-en-v1.5"`     | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
-| global.volume          | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
+| Key                     | Type   | Default                       | Description                                                                                                                                                  |
+| ----------------------- | ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| image.repository        | string | `"opea/embedding-tei:latest"` |                                                                                                                                                              |
+| service.port            | string | `"6000"`                      |                                                                                                                                                              |
+| tei.EMBEDDING_MODEL_ID  | string | `"BAAI/bge-base-en-v1.5"`     | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
+| global.modelUseHostPath | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -44,7 +44,6 @@ spec:
               value: {{ .Values.global.LANGCHAIN_API_KEY }}
             - name: LANGCHAIN_PROJECT
               value: "opea-embedding-service"
-
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -23,13 +23,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -64,5 +66,11 @@ tei:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "cpu-1.2"
+
 global:
-  volume: /mnt
+  http_proxy:
+  https_proxy:
+  no_proxy:
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/llm-uservice/README.md
+++ b/helm-charts/common/llm-uservice/README.md
@@ -14,17 +14,17 @@ helm dependency update llm-uservice
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt"
 export MODELNAME="m-a-p/OpenCodeInterpreter-DS-6.7B"
-helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.volume=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} --wait
+helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} --wait
 # To deploy on Gaudi enabled k8s cluster
-# helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.volume=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} --values llm-uservice/gaudi-values.yaml --wait
+# helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} --values llm-uservice/gaudi-values.yaml --wait
 ```
 
 ## Values
 
-| Key                             | Type   | Default                               | Description                                                                                                                              |
-| ------------------------------- | ------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                                  | Your own Hugging Face API token                                                                                                          |
-| global.volume                   | string | `"/mnt"`                              | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| image.repository                | string | `"opea/llm-tgi:latest"`               |                                                                                                                                          |
-| service.port                    | string | `"9000"`                              |                                                                                                                                          |
-| tgi.LLM_MODEL_ID                | string | `"m-a-p/OpenCodeInterpreter-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
+| Key                             | Type   | Default                               | Description                                                                                                                                                  |
+| ------------------------------- | ------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| global.HUGGINGFACEHUB_API_TOKEN | string | `""`                                  | Your own Hugging Face API token                                                                                                                              |
+| global.modelUseHostPath         | string | `"/mnt"`                              | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| image.repository                | string | `"opea/llm-tgi:latest"`               |                                                                                                                                                              |
+| service.port                    | string | `"9000"`                              |                                                                                                                                                              |
+| tgi.LLM_MODEL_ID                | string | `"m-a-p/OpenCodeInterpreter-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |

--- a/helm-charts/common/llm-uservice/gaudi-values.yaml
+++ b/helm-charts/common/llm-uservice/gaudi-values.yaml
@@ -23,13 +23,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -72,6 +74,8 @@ global:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -46,7 +46,6 @@ spec:
               value: {{ .Values.global.LANGCHAIN_API_KEY }}
             - name: LANGCHAIN_PROJECT
               value: "opea-llm-service"
-
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -23,13 +23,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -69,6 +71,8 @@ global:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/redis-vector-db/templates/deployment.yaml
+++ b/helm-charts/common/redis-vector-db/templates/deployment.yaml
@@ -29,11 +29,15 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          env:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /data
+              name: data-volume
+            - mountPath: /redisinsight
+              name: redisinsight-volume
           ports:
           {{- $redisServicePort := index .Values.service.ports 0 }}
             {{- range .Values.service.ports }}
@@ -49,6 +53,11 @@ spec:
             failureThreshold: 120
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+        - name: redisinsight-volume
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/redis-vector-db/values.yaml
+++ b/helm-charts/common/redis-vector-db/values.yaml
@@ -20,7 +20,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   ports:

--- a/helm-charts/common/reranking-usvc/README.md
+++ b/helm-charts/common/reranking-usvc/README.md
@@ -10,15 +10,14 @@ To install the chart, run the following:
 
 ```console
 $ export MODELDIR="/mnt"
-$ helm install reranking reranking-usvc --set global.volume=${MODELDIR}
+$ helm install reranking reranking-usvc --set global.modelUseHostPath=${MODELDIR}
 ```
 
 ## Values
 
-| Key                       | Type   | Default                       | Description                                                                                                                              |
-| ------------------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| image.repository          | string | `"opea/reranking-tgi:latest"` |                                                                                                                                          |
-| service.port              | string | `"8000"`                      |                                                                                                                                          |
-| teirerank.RERANK_MODEL_ID | string | `"BAAI/bge-reranker-base"`    | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
-| teirerank.port            | string | `"8000"`                      | Hugging Face Text Generation Inference service port                                                                                      |
-| global.volume             | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
+| Key                       | Type   | Default                       | Description                                                                                                                                                  |
+| ------------------------- | ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| image.repository          | string | `"opea/reranking-tgi:latest"` |                                                                                                                                                              |
+| service.port              | string | `"8000"`                      |                                                                                                                                                              |
+| teirerank.RERANK_MODEL_ID | string | `"BAAI/bge-reranker-base"`    | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
+| global.modelUseHostPath   | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |

--- a/helm-charts/common/reranking-usvc/templates/NOTES.txt
+++ b/helm-charts/common/reranking-usvc/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Get the application IP or URL by running these commands:
   export reranking_uservice_svc_ip=$(kubectl get svc --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "reranking-usvc.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].spec.clusterIP}") && echo ${reranking_uservice_svc_ip}
 2.   Use this command to verify tei service:
-  curl ${reranking_uservice_svc_ip}:6000/v1/rerankings\
+  curl ${reranking_uservice_svc_ip}:{{ .Values.service.port }}/v1/rerankings\
   -X POST \
-  -d '{"text":"hello"}' \
+  -d '{"initial_query":"What is Deep Learning?", "retrieved_docs": [{"text":"Deep Learning is not..."}, {"text":"Deep learning is..."}]}' \
   -H 'Content-Type: application/json'

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -44,7 +44,6 @@ spec:
               value: {{ .Values.global.LANGCHAIN_API_KEY }}
             - name: LANGCHAIN_PROJECT
               value: "opea-reranking-service"
-
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -23,13 +23,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -58,5 +60,11 @@ affinity: {}
 # To override values in subchart teirerank
 teirerank:
   RERANK_MODEL_ID: "BAAI/bge-reranker-base"
+
 global:
-  volume: /mnt
+  http_proxy:
+  https_proxy:
+  no_proxy:
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -22,13 +22,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -53,3 +55,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+global:
+  http_proxy:
+  https_proxy:
+  no_proxy:

--- a/helm-charts/common/tei/README.md
+++ b/helm-charts/common/tei/README.md
@@ -10,7 +10,7 @@ To install the chart, run the following:
 $ cd ${GenAIInfro_repo}/helm-charts/common
 $ export MODELDIR=/mnt/model
 $ export MODELNAME="BAAI/bge-base-en-v1.5"
-$ helm install tei tei --set global.volume=${MODELDIR} --set EMBEDDING_MODEL_ID=${MODELNAME}
+$ helm install tei tei --set global.modelUseHostPath=${MODELDIR} --set EMBEDDING_MODEL_ID=${MODELNAME}
 ```
 
 By default, the tei service will downloading the "BAAI/bge-base-en-v1.5" which is about 1.1GB.
@@ -23,10 +23,9 @@ MODELNAME="/data/BAAI/bge-base-en-v1.5"
 
 ## Values
 
-| Key                | Type   | Default                                           | Description                                                                                                                              |
-| ------------------ | ------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| EMBEDDING_MODEL_ID | string | `"BAAI/bge-base-en-v1.5"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
-| volume             | string | `"/mnt/model"`                                    | Cached models directory, tei will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| image.repository   | string | `"ghcr.io/huggingface/text-embeddings-inference"` |                                                                                                                                          |
-| image.tag          | string | `"cpu-1.2"`                                       |                                                                                                                                          |
-| service.port       | string | `"6006"`                                          | The service port                                                                                                                         |
+| Key                     | Type   | Default                                           | Description                                                                                                                                                  |
+| ----------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| EMBEDDING_MODEL_ID      | string | `"BAAI/bge-base-en-v1.5"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
+| global.modelUseHostPath | string | `"/mnt"`                                          | Cached models directory, tei will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| image.repository        | string | `"ghcr.io/huggingface/text-embeddings-inference"` |                                                                                                                                                              |
+| image.tag               | string | `"cpu-1.2"`                                       |                                                                                                                                                              |

--- a/helm-charts/common/tei/templates/NOTES.txt
+++ b/helm-charts/common/tei/templates/NOTES.txt
@@ -13,7 +13,7 @@
 {{- end }}
 
 2.   Use this command to verify tei service:
-  curl ${tei_svc_ip}:6006/embed \
+  curl http://${tei_svc_ip}/embed \
     -X POST \
     -d '{"inputs":"What is Deep Learning?"}' \
     -H 'Content-Type: application/json'

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -33,15 +33,23 @@ spec:
             - name: MODEL_ID
               value: {{ .Values.EMBEDDING_MODEL_ID | quote }}
             - name: PORT
-              value: "80"
+              value: {{ .Values.port | quote }}
             - name: http_proxy
               value: {{ .Values.global.http_proxy }}
             - name: https_proxy
               value: {{ .Values.global.https_proxy }}
             - name: no_proxy
               value: {{ .Values.global.no_proxy }}
+            - name: NUMBA_CACHE_DIR
+              value: /tmp
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
           securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
@@ -51,15 +59,19 @@ spec:
               name: shm
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.port }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
+          {{- if .Values.global.modelUseHostPath }}
           hostPath:
-            path: {{ .Values.global.volume }}
+            path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: shm
           emptyDir:
             medium: Memory

--- a/helm-charts/common/tei/templates/service.yaml
+++ b/helm-charts/common/tei/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: {{ .Values.port }}
       protocol: TCP
       name: tei
   selector:

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -7,6 +7,7 @@
 
 replicaCount: 1
 
+port: 2081
 shmSize: 1Gi
 EMBEDDING_MODEL_ID: "BAAI/bge-base-en-v1.5"
 image:
@@ -24,13 +25,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -54,4 +57,9 @@ tolerations: []
 affinity: {}
 
 global:
-  volume: /mnt
+  http_proxy:
+  https_proxy:
+  no_proxy:
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/teirerank/README.md
+++ b/helm-charts/common/teirerank/README.md
@@ -9,8 +9,8 @@ To install the chart, run the following:
 ```console
 $ cd ${GenAIInfro_repo}/helm-charts/common
 $ export MODELDIR=/mnt/model
-$ export MODELNAME="BAAI/bge-base-en-v1.5"
-$ helm install teirerank teirerank --set global.volume=${MODELDIR} --set EMBEDDING_MODEL_ID=${MODELNAME}
+$ export MODELNAME="BAAI/bge-reranker-base"
+$ helm install teirerank teirerank --set global.modelUseHostPath=${MODELDIR} --set RERANK_MODEL_ID=${MODELNAME}
 ```
 
 By default, the teirerank service will downloading the "BAAI/bge-base-en-v1.5" which is about 1.1GB.
@@ -23,10 +23,9 @@ MODELNAME="/data/BAAI/bge-base-en-v1.5"
 
 ## Values
 
-| Key                | Type   | Default                                           | Description                                                                                                                                    |
-| ------------------ | ------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| EMBEDDING_MODEL_ID | string | `"BAAI/bge-base-en-v1.5"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                       |
-| global.volume      | string | `"/mnt"`                                          | Cached models directory, teirerank will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| image.repository   | string | `"ghcr.io/huggingface/text-embeddings-inference"` |                                                                                                                                                |
-| image.tag          | string | `"cpu-1.2"`                                       |                                                                                                                                                |
-| service.port       | string | `"6006"`                                          | The service port                                                                                                                               |
+| Key                     | Type   | Default                                           | Description                                                                                                                                                        |
+| ----------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| RERANK_MODEL_ID         | string | `"BAAI/bge-reranker-base"`                        | Models id from https://huggingface.co/, or predownloaded model directory                                                                                           |
+| global.modelUseHostPath | string | `"/mnt"`                                          | Cached models directory, teirerank will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| image.repository        | string | `"ghcr.io/huggingface/text-embeddings-inference"` |                                                                                                                                                                    |
+| image.tag               | string | `"cpu-1.2"`                                       |                                                                                                                                                                    |

--- a/helm-charts/common/teirerank/templates/NOTES.txt
+++ b/helm-charts/common/teirerank/templates/NOTES.txt
@@ -13,7 +13,7 @@
 {{- end }}
 
 2.   Use this command to verify teirerank service:
-  curl ${teirerank_svc_ip}:6006/embed \
+  curl ${teirerank_svc_ip}/embed \
     -X POST \
     -d '{"inputs":"What is Deep Learning?"}' \
     -H 'Content-Type: application/json'

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -33,15 +33,23 @@ spec:
             - name: MODEL_ID
               value: {{ .Values.RERANK_MODEL_ID | quote }}
             - name: PORT
-              value: "80"
+              value: {{ .Values.port | quote }}
             - name: http_proxy
               value: {{ .Values.global.http_proxy }}
             - name: https_proxy
               value: {{ .Values.global.https_proxy }}
             - name: no_proxy
               value: {{ .Values.global.no_proxy }}
+            - name: NUMBA_CACHE_DIR
+              value: /tmp
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
           securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
@@ -51,15 +59,19 @@ spec:
               name: shm
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.port }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
+          {{- if .Values.global.modelUseHostPath }}
           hostPath:
-            path: {{ .Values.global.volume }}
+            path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: shm
           emptyDir:
             medium: Memory

--- a/helm-charts/common/teirerank/templates/service.yaml
+++ b/helm-charts/common/teirerank/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: {{ .Values.port }}
       protocol: TCP
       name: teirerank
   selector:

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -7,6 +7,7 @@
 
 replicaCount: 1
 
+port: 2082
 shmSize: 1Gi
 RERANK_MODEL_ID: "BAAI/bge-reranker-base"
 image:
@@ -24,13 +25,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -54,4 +57,9 @@ tolerations: []
 affinity: {}
 
 global:
-  volume: /mnt
+  http_proxy:
+  https_proxy:
+  no_proxy:
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/tgi/README.md
+++ b/helm-charts/common/tgi/README.md
@@ -10,9 +10,9 @@ To install the chart, run the following:
 cd GenAIInfra/helm-charts/common
 export MODELDIR=/mnt
 export MODELNAME="bigscience/bloom-560m"
-helm install tgi tgi --set global.volume=${MODELDIR} --set LLM_MODEL_ID=${MODELNAME}
+helm install tgi tgi --set global.modelUseHostPath=${MODELDIR} --set LLM_MODEL_ID=${MODELNAME}
 # To deploy on Gaudi enabled kubernetes cluster
-# helm install tgi tgi --set global.volume=${MODELDIR} --set LLM_MODEL_ID=${MODELNAME} --values tgi/gaudi-values.yaml
+# helm install tgi tgi --set global.modelUseHostPath=${MODELDIR} --set LLM_MODEL_ID=${MODELNAME} --values gaudi-values.yaml
 ```
 
 By default, the tgi service will downloading the "bigscience/bloom-560m" which is about 1.1GB.
@@ -25,10 +25,10 @@ MODELNAME="/data/models--bigscience--bloom-560m"
 
 ## Values
 
-| Key           | Type   | Default                                           | Description                                                                                                                              |
-| ------------- | ------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| LLM_MODEL_ID  | string | `"bigscience/bloom-560m"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                 |
-| port          | string | `"80"`                                            | Hugging Face Text Generation Inference service port                                                                                      |
-| global.volume | string | `"/mnt"`                                          | Cached models directory, tgi will not download if the model is cached here. The "volume" will be mounted to container as /data directory |
-| image         | string | `"ghcr.io/huggingface/text-generation-inference"` |                                                                                                                                          |
-| tag           | string | `"1.4"`                                           |                                                                                                                                          |
+| Key                     | Type   | Default                                           | Description                                                                                                                                                  |
+| ----------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| LLM_MODEL_ID            | string | `"bigscience/bloom-560m"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
+| port                    | string | `2080`                                            | Hugging Face Text Generation Inference service port                                                                                                          |
+| global.modelUseHostPath | string | `"/mnt"`                                          | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| image.repository        | string | `"ghcr.io/huggingface/text-generation-inference"` |                                                                                                                                                              |
+| image.tag               | string | `"1.4"`                                           |                                                                                                                                                              |

--- a/helm-charts/common/tgi/gaudi-values.yaml
+++ b/helm-charts/common/tgi/gaudi-values.yaml
@@ -7,15 +7,13 @@
 
 replicaCount: 1
 
-LLM_MODEL_ID: bigscience/bloom-560m
-# LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
-port: 80
+port: 2080
 
 image:
-  repository: ghcr.io/huggingface/text-generation-inference
+  repository: ghcr.io/huggingface/tgi-gaudi
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.4"
+  tag: "1.2.1"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -26,13 +24,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -46,16 +46,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
 # LLM_MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
 LLM_MODEL_ID: /data/Magicoder-S-DS-6.7B
-volume: /mnt
-image:
-  repository: ghcr.io/huggingface/tgi-gaudi
-  tag: "1.2.1"
 
 global:
   http_proxy:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt

--- a/helm-charts/common/tgi/templates/NOTES.txt
+++ b/helm-charts/common/tgi/templates/NOTES.txt
@@ -11,6 +11,6 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "tgi.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8080 to use your application"
 {{- end }}

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -44,8 +44,18 @@ spec:
               value: {{ .Values.global.https_proxy }}
             - name: no_proxy
               value: {{ .Values.global.no_proxy }}
+            - name: HABANA_LOGS
+              value: /tmp/habana_logs
+            - name: NUMBA_CACHE_DIR
+              value: /tmp/numba_cache
+            - name: TRANSFORMERS_CACHE
+              value: /tmp/transformers_cache
           securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
@@ -59,9 +69,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
+          {{- if .Values.global.modelUseHostPath }}
           hostPath:
-            path: {{ .Values.global.volume }}
+            path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -7,9 +7,7 @@
 
 replicaCount: 1
 
-LLM_MODEL_ID: bigscience/bloom-560m
-# LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
-port: 80
+port: 2080
 
 image:
   repository: ghcr.io/huggingface/text-generation-inference
@@ -26,13 +24,15 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -55,9 +55,14 @@ tolerations: []
 
 affinity: {}
 
+LLM_MODEL_ID: bigscience/bloom-560m
+# LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
+
 global:
   http_proxy:
   https_proxy:
   no_proxy:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  volume: /mnt
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt


### PR DESCRIPTION
## Description

Add default minimal pod security to meet [K8S restricted pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted). 

Rename the helm-chart option `global.volume` to `global.modelUseHostPath`. Set it to null or empty value will result the emptyDir type of volumes to be mounted into the container and apply the the pod security as much as possible to meet restricted pod security standard.

## Issues

issue #129

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a

## Tests

n/a
