### PR TITLE
helm chart: make readOnlyRootFilesystem as default

### DIFF
--- a/.github/workflows/scripts/e2e/chart_test.sh
+++ b/.github/workflows/scripts/e2e/chart_test.sh
@@ -21,7 +21,7 @@ function init_codegen() {
 
 function init_chatqna() {
     # replace volume: /mnt with volume: $CHART_MOUNT
-    find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: /mnt#modelUseHostPath: $CHART_MOUNT#g" {} \;
+    find . -name '*values.yaml' -type f -exec sed -i "s#modelUseHostPath: .*#modelUseHostPath: $CHART_MOUNT#g" {} \;
     # replace the repository "image: opea/*" with "image: ${IMAGE_REPO}opea/"
     find .. -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token

--- a/helm-charts/chatqna/README.md
+++ b/helm-charts/chatqna/README.md
@@ -11,7 +11,7 @@ cd GenAIInfra/helm-charts/
 ./update_dependency.sh
 helm dependency update chatqna
 export HFTOKEN="insert-your-huggingface-token-here"
-export MODELDIR="/mnt"
+export MODELDIR="/mnt/opea-models"
 export MODELNAME="Intel/neural-chat-7b-v3-3"
 helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
 # To use Gaudi device
@@ -25,5 +25,5 @@ helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --
 | image.repository                | string | `"opea/chatqna:latest"`       |                                                                                                                                                    |
 | service.port                    | string | `"8888"`                      |                                                                                                                                                    |
 | global.HUGGINGFACEHUB_API_TOKEN | string | `""`                          | Your own Hugging Face API token                                                                                                                    |
-| global.modelUseHostPath         | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "volume" will be mounted to container as /data directory |
+| global.modelUseHostPath         | string | `"/mnt/opea-models"`          | Cached models directory, tgi will not download if the model is cached here. The host path "volume" will be mounted to container as /data directory |
 | llm-uservice.tgi.LLM_MODEL_ID   | string | `"Intel/neural-chat-7b-v3-3"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                           |

--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -50,4 +50,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -19,6 +19,7 @@ service:
   port: 8888
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/chatqna/templates/deployment.yaml
+++ b/helm-charts/chatqna/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           ports:
             - name: chatqna
               containerPort: {{ .Values.port }}
@@ -64,6 +67,9 @@ spec:
                 #              port: {{ .Values.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -44,4 +44,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -19,6 +19,7 @@ service:
   port: 8888
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -13,7 +13,7 @@ cd GenAIInfra/helm-charts/
 ./update_dependency.sh
 helm dependency update codegen
 export HFTOKEN="insert-your-huggingface-token-here"
-export MODELDIR="/mnt"
+export MODELDIR="/mnt/opea-models"
 export MODELNAME="m-a-p/OpenCodeInterpreter-DS-6.7B"
 helm install codegen codegen --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservice.tgi.LLM_MODEL_ID=${MODELNAME}
 # To use Gaudi device
@@ -27,5 +27,5 @@ helm install codegen codegen --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --
 | image.repository                | string | `"opea/codegen:latest"`          |                                                                                                                                                              |
 | service.port                    | string | `"7778"`                         |                                                                                                                                                              |
 | global.HUGGINGFACEHUB_API_TOKEN | string | `""`                             | Your own Hugging Face API token                                                                                                                              |
-| global.modelUseHostPath         | string | `"/mnt"`                         | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath         | string | `"/mnt/opea-models"`             | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
 | llm-uservice.tgi.LLM_MODEL_ID   | string | `"ise-uiuc/Magicoder-S-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |

--- a/helm-charts/codegen/gaudi-values.yaml
+++ b/helm-charts/codegen/gaudi-values.yaml
@@ -19,6 +19,7 @@ service:
   port: 7778
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/codegen/gaudi-values.yaml
+++ b/helm-charts/codegen/gaudi-values.yaml
@@ -54,4 +54,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/codegen/templates/deployment.yaml
+++ b/helm-charts/codegen/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           ports:
             - name: codegen
               containerPort: {{ .Values.port }}
@@ -60,6 +63,9 @@ spec:
                 #              port: {{ .Values.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -19,6 +19,7 @@ service:
   port: 7778
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -48,4 +48,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/embedding-usvc/README.md
+++ b/helm-charts/common/embedding-usvc/README.md
@@ -9,7 +9,7 @@ embedding-usvc depends on TEI, refer to tei for more config details.
 To install the chart, run the following:
 
 ```console
-$ export MODELDIR="/mnt"
+$ export MODELDIR="/mnt/opea-models"
 $ export MODELNAME="BAAI/bge-base-en-v1.5"
 $ helm install embedding embedding-usvc --set global.modelUseHostPath=${MODELDIR} --set tei.EMBEDDING_MODEL_ID=${MODELNAME}
 ```
@@ -21,4 +21,4 @@ $ helm install embedding embedding-usvc --set global.modelUseHostPath=${MODELDIR
 | image.repository        | string | `"opea/embedding-tei:latest"` |                                                                                                                                                              |
 | service.port            | string | `"6000"`                      |                                                                                                                                                              |
 | tei.EMBEDDING_MODEL_ID  | string | `"BAAI/bge-base-en-v1.5"`     | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
-| global.modelUseHostPath | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath | string | `"/mnt/opea-models"`          | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -52,8 +52,14 @@ spec:
             - name: embedding-usvc
               containerPort:  {{ .Values.service.targetPort }}
               protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -73,4 +73,4 @@ global:
   no_proxy:
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -24,6 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/llm-uservice/README.md
+++ b/helm-charts/common/llm-uservice/README.md
@@ -12,7 +12,7 @@ To install the chart, run the following:
 cd GenAIInfra/helm-charts/common
 helm dependency update llm-uservice
 export HFTOKEN="insert-your-huggingface-token-here"
-export MODELDIR="/mnt"
+export MODELDIR="/mnt/opea-models"
 export MODELNAME="m-a-p/OpenCodeInterpreter-DS-6.7B"
 helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} --wait
 # To deploy on Gaudi enabled k8s cluster
@@ -24,7 +24,7 @@ helm install llm llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} -
 | Key                             | Type   | Default                               | Description                                                                                                                                                  |
 | ------------------------------- | ------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | global.HUGGINGFACEHUB_API_TOKEN | string | `""`                                  | Your own Hugging Face API token                                                                                                                              |
-| global.modelUseHostPath         | string | `"/mnt"`                              | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath         | string | `"/mnt/opea-models"`                  | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
 | image.repository                | string | `"opea/llm-tgi:latest"`               |                                                                                                                                                              |
 | service.port                    | string | `"9000"`                              |                                                                                                                                                              |
 | tgi.LLM_MODEL_ID                | string | `"m-a-p/OpenCodeInterpreter-DS-6.7B"` | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |

--- a/helm-charts/common/llm-uservice/gaudi-values.yaml
+++ b/helm-charts/common/llm-uservice/gaudi-values.yaml
@@ -24,6 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/llm-uservice/gaudi-values.yaml
+++ b/helm-charts/common/llm-uservice/gaudi-values.yaml
@@ -78,4 +78,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
               value: "http://{{ .Release.Name }}-tgi"
             - name: HUGGINGFACEHUB_API_TOKEN
               value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+            - name: HF_HOME
+              value: "/tmp/.cache/huggingface"
             - name: http_proxy
               value: {{ .Values.global.http_proxy }}
             - name: https_proxy
@@ -54,6 +56,9 @@ spec:
             - name: llm-uservice
               containerPort: 9000
               protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           startupProbe:
             exec:
               command:
@@ -64,6 +69,9 @@ spec:
             failureThreshold: 120
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -75,4 +75,4 @@ global:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -24,6 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/redis-vector-db/templates/deployment.yaml
+++ b/helm-charts/common/redis-vector-db/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
               name: data-volume
             - mountPath: /redisinsight
               name: redisinsight-volume
+            - mountPath: /tmp
+              name: tmp
           ports:
           {{- $redisServicePort := index .Values.service.ports 0 }}
             {{- range .Values.service.ports }}
@@ -57,6 +59,8 @@ spec:
         - name: data-volume
           emptyDir: {}
         - name: redisinsight-volume
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-charts/common/redis-vector-db/values.yaml
+++ b/helm-charts/common/redis-vector-db/values.yaml
@@ -21,6 +21,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/reranking-usvc/README.md
+++ b/helm-charts/common/reranking-usvc/README.md
@@ -9,7 +9,7 @@ reranking-usvc depends on TEI, refer to teirerank for more config details.
 To install the chart, run the following:
 
 ```console
-$ export MODELDIR="/mnt"
+$ export MODELDIR="/mnt/opea-models"
 $ helm install reranking reranking-usvc --set global.modelUseHostPath=${MODELDIR}
 ```
 
@@ -20,4 +20,4 @@ $ helm install reranking reranking-usvc --set global.modelUseHostPath=${MODELDIR
 | image.repository          | string | `"opea/reranking-tgi:latest"` |                                                                                                                                                              |
 | service.port              | string | `"8000"`                      |                                                                                                                                                              |
 | teirerank.RERANK_MODEL_ID | string | `"BAAI/bge-reranker-base"`    | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
-| global.modelUseHostPath   | string | `"/mnt"`                      | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath   | string | `"/mnt/opea-models"`          | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -52,8 +52,14 @@ spec:
             - name: reranking-usvc
               containerPort:  {{ .Values.service.targetPort }}
               protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -67,4 +67,4 @@ global:
   no_proxy:
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -24,6 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
               value: "redis://{{ .Release.Name }}-redis-vector-db:6379"
             - name: INDEX_NAME
               value: "rag-redis"
+            - name: EASYOCR_MODULE_PATH
+              value: "/tmp/.EasyOCR"
             - name: http_proxy
               value: {{ .Values.global.http_proxy }}
             - name: https_proxy
@@ -48,6 +50,8 @@ spec:
               value: {{ .Values.global.LANGCHAIN_API_KEY }}
             - name: LANGCHAIN_PROJECT
               value: "opea-retriever-service"
+            - name: HF_HOME
+              value: "/tmp/.cache/huggingface"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"
@@ -56,6 +60,9 @@ spec:
             - name: retriever-usvc
               containerPort: 7000
               protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           startupProbe:
             exec:
               command:
@@ -74,6 +81,9 @@ spec:
 #              port: 7000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -23,6 +23,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: /tmp
             - name: TRANSFORMERS_CACHE
               value: /tmp/transformers_cache
+            - name: HF_HOME
+              value: "/tmp/.cache/huggingface"
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}
@@ -57,6 +59,8 @@ spec:
               name: model-volume
             - mountPath: /dev/shm
               name: shm
+            - mountPath: /tmp
+              name: tmp
           ports:
             - name: http
               containerPort: {{ .Values.port }}
@@ -76,6 +80,8 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.shmSize }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -62,4 +62,4 @@ global:
   no_proxy:
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -26,6 +26,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/teirerank/README.md
+++ b/helm-charts/common/teirerank/README.md
@@ -8,7 +8,7 @@ To install the chart, run the following:
 
 ```console
 $ cd ${GenAIInfro_repo}/helm-charts/common
-$ export MODELDIR=/mnt/model
+$ export MODELDIR=/mnt/opea-models
 $ export MODELNAME="BAAI/bge-reranker-base"
 $ helm install teirerank teirerank --set global.modelUseHostPath=${MODELDIR} --set RERANK_MODEL_ID=${MODELNAME}
 ```
@@ -26,6 +26,6 @@ MODELNAME="/data/BAAI/bge-base-en-v1.5"
 | Key                     | Type   | Default                                           | Description                                                                                                                                                        |
 | ----------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | RERANK_MODEL_ID         | string | `"BAAI/bge-reranker-base"`                        | Models id from https://huggingface.co/, or predownloaded model directory                                                                                           |
-| global.modelUseHostPath | string | `"/mnt"`                                          | Cached models directory, teirerank will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath | string | `"/mnt/opea-models"`                              | Cached models directory, teirerank will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
 | image.repository        | string | `"ghcr.io/huggingface/text-embeddings-inference"` |                                                                                                                                                                    |
 | image.tag               | string | `"cpu-1.2"`                                       |                                                                                                                                                                    |

--- a/helm-charts/common/teirerank/templates/NOTES.txt
+++ b/helm-charts/common/teirerank/templates/NOTES.txt
@@ -13,7 +13,7 @@
 {{- end }}
 
 2.   Use this command to verify teirerank service:
-  curl ${teirerank_svc_ip}/embed \
+  curl ${teirerank_svc_ip}/rerank\
     -X POST \
-    -d '{"inputs":"What is Deep Learning?"}' \
+    -d '{"query":"What is Deep Learning?", "texts": ["Deep Learning is not...", "Deep learning is..."]}' \
     -H 'Content-Type: application/json'

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
               value: /tmp
             - name: TRANSFORMERS_CACHE
               value: /tmp/transformers_cache
+            - name: HF_HOME
+              value: "/tmp/.cache/huggingface"
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}
@@ -57,6 +59,8 @@ spec:
               name: model-volume
             - mountPath: /dev/shm
               name: shm
+            - mountPath: /tmp
+              name: tmp
           ports:
             - name: http
               containerPort: {{ .Values.port }}
@@ -76,6 +80,8 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.shmSize }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -62,4 +62,4 @@ global:
   no_proxy:
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -26,6 +26,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/tgi/README.md
+++ b/helm-charts/common/tgi/README.md
@@ -8,7 +8,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/common
-export MODELDIR=/mnt
+export MODELDIR=/mnt/opea-models
 export MODELNAME="bigscience/bloom-560m"
 helm install tgi tgi --set global.modelUseHostPath=${MODELDIR} --set LLM_MODEL_ID=${MODELNAME}
 # To deploy on Gaudi enabled kubernetes cluster
@@ -29,6 +29,6 @@ MODELNAME="/data/models--bigscience--bloom-560m"
 | ----------------------- | ------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | LLM_MODEL_ID            | string | `"bigscience/bloom-560m"`                         | Models id from https://huggingface.co/, or predownloaded model directory                                                                                     |
 | port                    | string | `2080`                                            | Hugging Face Text Generation Inference service port                                                                                                          |
-| global.modelUseHostPath | string | `"/mnt"`                                          | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
+| global.modelUseHostPath | string | `"/mnt/opea-models"`                              | Cached models directory, tgi will not download if the model is cached here. The host path "modelUseHostPath" will be mounted to container as /data directory |
 | image.repository        | string | `"ghcr.io/huggingface/text-generation-inference"` |                                                                                                                                                              |
 | image.tag               | string | `"1.4"`                                           |                                                                                                                                                              |

--- a/helm-charts/common/tgi/gaudi-values.yaml
+++ b/helm-charts/common/tgi/gaudi-values.yaml
@@ -25,6 +25,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/tgi/gaudi-values.yaml
+++ b/helm-charts/common/tgi/gaudi-values.yaml
@@ -57,4 +57,4 @@ global:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: /tmp/numba_cache
             - name: TRANSFORMERS_CACHE
               value: /tmp/transformers_cache
+            - name: HF_HOME
+              value: "/tmp/.cache/huggingface"
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}
@@ -61,6 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: model-volume
+            - mountPath: /tmp
+              name: tmp
           ports:
             - name: http
               containerPort: {{ .Values.port }}
@@ -76,6 +80,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -25,6 +25,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -65,4 +65,4 @@ global:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
-  modelUseHostPath: /mnt
+  modelUseHostPath: /mnt/opea-models


### PR DESCRIPTION
## Description

This PR brings more security into the default settings:
- Change default modelUseHostPath to /mnt/opea-models to avoid overwrite universal /mnt
- Add readOnlyRootFilesystem to all default securityContext settings

## Issues

#129 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
