### PR TITLE
Add MAX_INPUT_TOKENS to tgi

### DIFF
--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
               value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
             - name: HF_TOKEN
               value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+            - name: MAX_INPUT_TOKENS
+              value: "1024"
+            - name: MAX_TOTAL_TOKENS
+              value: "4096"
             - name: http_proxy
               value: {{ .Values.global.http_proxy }}
             - name: https_proxy


### PR DESCRIPTION
New tgi 2.0.0 version will set MAX_INPUT_TOKENS to 4095 by default. This will cause tgi error. First set to 1024 as default, may make it configurable by user later.

## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

‘n/a'

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
