### PR TITLE
helm chart: Allow users to set extra env by external configmap

### DIFF
--- a/helm-charts/chatqna/Chart.yaml
+++ b/helm-charts/chatqna/Chart.yaml
@@ -7,31 +7,31 @@ description: The Helm chart to deploy ChatQnA
 type: application
 dependencies:
   - name: tgi
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/llm-uservice"
   - name: tei
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/tei"
   - name: embedding-usvc
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/embedding-usvc"
   - name: teirerank
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/teirerank"
   - name: reranking-usvc
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/reranking-usvc"
   - name: redis-vector-db
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/redis-vector-db"
   - name: retriever-usvc
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/retriever-usvc"
   - name: data-prep
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/data-prep"
-version: 0.1.0
+version: 0.8.0
 appVersion: "1.0.0"

--- a/helm-charts/codegen/Chart.yaml
+++ b/helm-charts/codegen/Chart.yaml
@@ -7,10 +7,10 @@ description: The Helm chart to deploy CodeGen
 type: application
 dependencies:
   - name: tgi
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: "0.1.0"
+    version: 0.8.0
     repository: "file://../common/llm-uservice"
-version: 0.1.0
+version: 0.8.0
 appVersion: "1.0.0"

--- a/helm-charts/common/data-prep/Chart.yaml
+++ b/helm-charts/common/data-prep/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: data-prep
 description: The Helm chart for deploying data prep as microservice
 type: application
-version: 0.1.0
+version: 0.8.0
 # The data prep microservice server version
 appVersion: "1.0.0"

--- a/helm-charts/common/data-prep/templates/configmap.yaml
+++ b/helm-charts/common/data-prep/templates/configmap.yaml
@@ -1,0 +1,29 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "data-prep.fullname" . }}-config
+  labels:
+    {{- include "data-prep.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  TEI_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
+  {{- else }}
+  TEI_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  {{- end }}
+  {{- if .Values.REDIS_URL }}
+  REDIS_URL: {{ .Values.REDIS_URL | quote}}
+  {{- else }}
+  REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db:6379"
+  {{- end }}
+  INDEX_NAME: "rag-redis"
+  HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+  HF_HOME: "/tmp/.cache/huggingface"
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  LANGCHAIN_TRACING_V2: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
+  LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY | quote }}
+  LANGCHAIN_PROJECT: "opea-dataprep-service"

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -29,37 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TEI_ENDPOINT
-              {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
-              value: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-tei"
-              {{- end }}
-            - name: REDIS_URL
-              {{- if .Values.REDIS_URL }}
-              value: {{ .Values.REDIS_URL | quote}}
-              {{- else }}
-              value: "redis://{{ .Release.Name }}-redis-vector-db:6379"
-              {{- end }}
-            - name: INDEX_NAME
-              value: "rag-redis"
-            - name: HUGGINGFACEHUB_API_TOKEN
-              value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: LANGCHAIN_TRACING_V2
-              value: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
-            - name: LANGCHAIN_API_KEY
-              value: {{ .Values.global.LANGCHAIN_API_KEY }}
-            - name: LANGCHAIN_PROJECT
-              value: "opea-dataprep-service"
+          envFrom:
+            - configMapRef:
+                name: {{ include "data-prep.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -56,6 +56,12 @@ tolerations: []
 
 affinity: {}
 
+# text embedding inference service URL, e.g. http://<service-name>:<port>
+TEI_EMBEDDING_ENDPOINT: ""
+
+# redis DB service URL, e.g. redis://<service-name>:<port>
+REDIS_URL: ""
+
 global:
   http_proxy:
   https_proxy:

--- a/helm-charts/common/embedding-usvc/Chart.yaml
+++ b/helm-charts/common/embedding-usvc/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: embedding-usvc
 description: The Helm chart for deploying embedding as microservice
 type: application
-version: 0.1.0
+version: 0.8.0
 # The embedding microservice server version
 appVersion: "1.0.0"

--- a/helm-charts/common/embedding-usvc/templates/configmap.yaml
+++ b/helm-charts/common/embedding-usvc/templates/configmap.yaml
@@ -1,0 +1,21 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "embedding-usvc.fullname" . }}-config
+  labels:
+    {{- include "embedding-usvc.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote }}
+  {{- else }}
+  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  {{- end }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  LANGCHAIN_TRACING_V2: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
+  LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY }}
+  LANGCHAIN_PROJECT: "opea-embedding-service"

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -29,25 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TEI_EMBEDDING_ENDPOINT
-              {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
-              value: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-tei"
-              {{- end }}
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: LANGCHAIN_TRACING_V2
-              value: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
-            - name: LANGCHAIN_API_KEY
-              value: {{ .Values.global.LANGCHAIN_API_KEY }}
-            - name: LANGCHAIN_PROJECT
-              value: "opea-embedding-service"
+          envFrom:
+            - configMapRef:
+                name: {{ include "embedding-usvc.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/llm-uservice/Chart.yaml
+++ b/helm-charts/common/llm-uservice/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: llm-uservice
 description: The Helm chart for deploying llm as microservice
 type: application
-version: 0.1.0
+version: 0.8.0
 # The llm microservice server version
 appVersion: "1.0.0"

--- a/helm-charts/common/llm-uservice/templates/configmap.yaml
+++ b/helm-charts/common/llm-uservice/templates/configmap.yaml
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llm-uservice.fullname" . }}-config
+  labels:
+    {{- include "llm-uservice.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TGI_LLM_ENDPOINT }}
+  TGI_LLM_ENDPOINT: {{ .Values.TGI_LLM_ENDPOINT | quote}}
+  {{- else }}
+  TGI_LLM_ENDPOINT: "http://{{ .Release.Name }}-tgi"
+  {{- end }}
+  HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+  HF_HOME: "/tmp/.cache/huggingface"
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  LANGCHAIN_TRACING_V2: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
+  LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY }}
+  LANGCHAIN_PROJECT: "opea-llm-uservice"

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -29,29 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TGI_LLM_ENDPOINT
-              {{- if .Values.TGI_LLM_ENDPOINT }}
-              value: {{ .Values.TGI_LLM_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-tgi"
-              {{- end }}
-            - name: HUGGINGFACEHUB_API_TOKEN
-              value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: LANGCHAIN_TRACING_V2
-              value: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
-            - name: LANGCHAIN_API_KEY
-              value: {{ .Values.global.LANGCHAIN_API_KEY }}
-            - name: LANGCHAIN_PROJECT
-              value: "opea-llm-service"
+          envFrom:
+            - configMapRef:
+                name: {{ include "llm-uservice.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -24,7 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false
   runAsNonRoot: true
   runAsUser: 1000

--- a/helm-charts/common/redis-vector-db/Chart.yaml
+++ b/helm-charts/common/redis-vector-db/Chart.yaml
@@ -5,6 +5,5 @@ apiVersion: v2
 name: redis-vector-db
 description: The Helm chart for Redis Vector DB
 type: application
-version: 0.1.0
-# The HF TEI version
-appVersion: "1.0"
+version: 0.8.0
+appVersion: "7.2.0-v9"

--- a/helm-charts/common/reranking-usvc/Chart.yaml
+++ b/helm-charts/common/reranking-usvc/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: reranking-usvc
 description: The Helm chart for deploying reranking as microservice
 type: application
-version: 0.1.0
+version: 0.8.0
 # The reranking microservice server version
 appVersion: "1.0.0"

--- a/helm-charts/common/reranking-usvc/templates/configmap.yaml
+++ b/helm-charts/common/reranking-usvc/templates/configmap.yaml
@@ -1,0 +1,21 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "reranking-usvc.fullname" . }}-config
+  labels:
+    {{- include "reranking-usvc.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TEI_RERANKING_ENDPOINT }}
+  TEI_RERANKING_ENDPOINT: {{ .Values.TEI_RERANKING_ENDPOINT | quote }}
+  {{- else }}
+  TEI_RERANKING_ENDPOINT: "http://{{ .Release.Name }}-teirerank"
+  {{- end }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  LANGCHAIN_TRACING_V2: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
+  LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY | quote }}
+  LANGCHAIN_PROJECT: "opea-reranking-service"

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -29,25 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TEI_RERANKING_ENDPOINT
-              {{- if .Values.TEI_RERANKING_ENDPOINT }}
-              value: {{ .Values.TEI_RERANKING_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-teirerank"
-              {{- end }}
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: LANGCHAIN_TRACING_V2
-              value: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
-            - name: LANGCHAIN_API_KEY
-              value: {{ .Values.global.LANGCHAIN_API_KEY }}
-            - name: LANGCHAIN_PROJECT
-              value: "opea-reranking-service"
+          envFrom:
+            - configMapRef:
+                name: {{ include "reranking-usvc.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/retriever-usvc/Chart.yaml
+++ b/helm-charts/common/retriever-usvc/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: retriever-usvc
 description: The Helm chart for deploying retriever as microservice
 type: application
-version: 0.1.0
+version: 0.8.0
 # The retriever microservice server version
 appVersion: "1.0.0"

--- a/helm-charts/common/retriever-usvc/templates/configmap.yaml
+++ b/helm-charts/common/retriever-usvc/templates/configmap.yaml
@@ -1,0 +1,29 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "retriever-usvc.fullname" . }}-config
+  labels:
+    {{- include "retriever-usvc.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote }}
+  {{- else }}
+  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  {{- end }}
+  {{- if .Values.REDIS_URL }}
+  REDIS_URL: {{ .Values.REDIS_URL | quote}}
+  {{- else }}
+  REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db:6379"
+  {{- end }}
+  INDEX_NAME: "rag-redis"
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  LANGCHAIN_TRACING_V2: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
+  LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY | quote }}
+  LANGCHAIN_PROJECT: "opea-retriever-service"
+  HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -29,37 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TEI_EMBEDDING_ENDPOINT
-              {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
-              value: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-tei"
-              {{- end }}
-            - name: REDIS_URL
-              {{- if .Values.REDIS_URL }}
-              value: {{ .Values.REDIS_URL | quote}}
-              {{- else }}
-              value: "redis://{{ .Release.Name }}-redis-vector-db:6379"
-              {{- end }}
-            - name: INDEX_NAME
-              value: "rag-redis"
-            - name: EASYOCR_MODULE_PATH
-              value: "/tmp/.EasyOCR"
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: LANGCHAIN_TRACING_V2
-              value: {{ .Values.global.LANGCHAIN_TRACING_V2 | quote }}
-            - name: LANGCHAIN_API_KEY
-              value: {{ .Values.global.LANGCHAIN_API_KEY }}
-            - name: LANGCHAIN_PROJECT
-              value: "opea-retriever-service"
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
+          envFrom:
+            - configMapRef:
+                name: {{ include "retriever-usvc.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"

--- a/helm-charts/common/tei/Chart.yaml
+++ b/helm-charts/common/tei/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tei
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 0.1.0
+version: 0.8.0
 # The HF TEI version
 appVersion: "1.2"

--- a/helm-charts/common/tei/templates/configmap.yaml
+++ b/helm-charts/common/tei/templates/configmap.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tei.fullname" . }}-config
+  labels:
+    {{- include "tei.labels" . | nindent 4 }}
+data:
+  MODEL_ID: {{ .Values.EMBEDDING_MODEL_ID | quote }}
+  PORT: {{ .Values.port | quote }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -29,23 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          env:
-            - name: MODEL_ID
-              value: {{ .Values.EMBEDDING_MODEL_ID | quote }}
-            - name: PORT
-              value: {{ .Values.port | quote }}
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: NUMBA_CACHE_DIR
-              value: /tmp
-            - name: TRANSFORMERS_CACHE
-              value: /tmp/transformers_cache
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
+          envFrom:
+            - configMapRef:
+                name: {{ include "tei.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}

--- a/helm-charts/common/teirerank/Chart.yaml
+++ b/helm-charts/common/teirerank/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: teirerank
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 0.1.0
+version: 0.8.0
 # The HF TEI version
 appVersion: "1.2"

--- a/helm-charts/common/teirerank/templates/configmap.yaml
+++ b/helm-charts/common/teirerank/templates/configmap.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "teirerank.fullname" . }}-config
+  labels:
+    {{- include "teirerank.labels" . | nindent 4 }}
+data:
+  MODEL_ID: {{ .Values.RERANK_MODEL_ID | quote }}
+  PORT: {{ .Values.port | quote }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -29,23 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          env:
-            - name: MODEL_ID
-              value: {{ .Values.RERANK_MODEL_ID | quote }}
-            - name: PORT
-              value: {{ .Values.port | quote }}
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: NUMBA_CACHE_DIR
-              value: /tmp
-            - name: TRANSFORMERS_CACHE
-              value: /tmp/transformers_cache
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
+          envFrom:
+            - configMapRef:
+                name: {{ include "teirerank.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}

--- a/helm-charts/common/tgi/Chart.yaml
+++ b/helm-charts/common/tgi/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tgi
 description: The Helm chart for HuggingFace Text Generation Inference Server
 type: application
-version: 0.1.0
+version: 0.8.0
 # The HF TGI version
 appVersion: "1.4"

--- a/helm-charts/common/tgi/templates/configmap.yaml
+++ b/helm-charts/common/tgi/templates/configmap.yaml
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tgi.fullname" . }}-config
+  labels:
+    {{- include "tgi.labels" . | nindent 4 }}
+data:
+  MODEL_ID: {{ .Values.LLM_MODEL_ID | quote }}
+  PORT: {{ .Values.port | quote }}
+  HUGGING_FACE_HUB_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+  HF_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+  MAX_INPUT_TOKENS: "1024"
+  MAX_TOTAL_TOKENS: "4096"
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  HABANA_LOGS: "/tmp/habana_logs"
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -29,33 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          env:
-            - name: MODEL_ID
-              value: {{ .Values.LLM_MODEL_ID }}
-            - name: PORT
-              value: {{ .Values.port | quote }}
-            - name: HUGGING_FACE_HUB_TOKEN
-              value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
-            - name: HF_TOKEN
-              value: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
-            - name: MAX_INPUT_TOKENS
-              value: "1024"
-            - name: MAX_TOTAL_TOKENS
-              value: "4096"
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: HABANA_LOGS
-              value: /tmp/habana_logs
-            - name: NUMBA_CACHE_DIR
-              value: /tmp/numba_cache
-            - name: TRANSFORMERS_CACHE
-              value: /tmp/transformers_cache
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
+          envFrom:
+            - configMapRef:
+                name: {{ include "tgi.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- if .Values.global.modelUseHostPath }}
             {}

--- a/helm-charts/common/web-retriever/templates/configmap.yaml
+++ b/helm-charts/common/web-retriever/templates/configmap.yaml
@@ -1,0 +1,22 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "web-retriever.fullname" . }}-config
+  labels:
+    {{- include "web-retriever.labels" . | nindent 4 }}
+data:
+  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
+  {{- else }}
+  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  {{- end }}
+  GOOGLE_API_KEY: {{ .Values.GOOGLE_API_KEY | quote }}
+  GOOGLE_CSE_ID: {{ .Values.GOOGLE_CSE_ID | quote }}
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/web-retriever/templates/deployment.yaml
+++ b/helm-charts/common/web-retriever/templates/deployment.yaml
@@ -29,27 +29,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Release.Name }}
-          env:
-            - name: TEI_EMBEDDING_ENDPOINT
-              {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
-              value: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
-              {{- else }}
-              value: "http://{{ .Release.Name }}-tei"
-              {{- end }}
-            - name: GOOGLE_API_KEY
-              value: {{ .Values.GOOGLE_API_KEY }}
-            - name: GOOGLE_CSE_ID
-              value: {{ .Values.GOOGLE_CSE_ID }}
-            - name: EASYOCR_MODULE_PATH
-              value: "/tmp/.EasyOCR"
-            - name: http_proxy
-              value: {{ .Values.global.http_proxy }}
-            - name: https_proxy
-              value: {{ .Values.global.https_proxy }}
-            - name: no_proxy
-              value: {{ .Values.global.no_proxy }}
-            - name: HF_HOME
-              value: "/tmp/.cache/huggingface"
+          envFrom:
+            - configMapRef:
+                name: {{ include "web-retriever.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}"


### PR DESCRIPTION
## Description

- Allow users to set extra env by external configmap through global.extraEnvConfig
- export data-prep configuration items into its value file
- bump chart version to upcoming 0.8.0 and adapted to v0.7 opea docker images

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

n/a

## Tests

verified on Xeon with recently published opea docker image(v0.7)
