### PR TITLE
Update comp manifest generation 

### DIFF
--- a/helm-charts/common/asr/templates/deployment.yaml
+++ b/helm-charts/common/asr/templates/deployment.yaml
@@ -48,26 +48,6 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-                #startupProbe:
-                #  exec:
-                #    command:
-                #    - curl
-                #    {{- if .Values.ASR_ENDPOINT }}
-                #    - {{ .Values.ASR_ENDPOINT }}
-                #    {{- else }}
-                #    - http://{{ .Release.Name }}-whisper
-                #    {{- end }}
-                #  initialDelaySeconds: 5
-                #  periodSeconds: 5
-                #  failureThreshold: 120
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-charts/common/asr/values.yaml
+++ b/helm-charts/common/asr/values.yaml
@@ -59,6 +59,6 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -48,14 +48,6 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -63,9 +63,9 @@ TEI_EMBEDDING_ENDPOINT: ""
 REDIS_URL: ""
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -58,10 +58,12 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   # HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  LANGCHAIN_TRACING_V2: false
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
+          {{- if not .Values.noProbe }}
           startupProbe:
             exec:
               command:
@@ -60,6 +61,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 120
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -58,9 +58,9 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"

--- a/helm-charts/common/redis-vector-db/values.yaml
+++ b/helm-charts/common/redis-vector-db/values.yaml
@@ -5,6 +5,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+replicaCount: 1
 image:
   repository: redis/redis-stack
   pullPolicy: IfNotPresent
@@ -32,15 +33,16 @@ securityContext:
     type: RuntimeDefault
 
 service:
+  type: ClusterIP
   ports:
   - name: redis-service
-    type: ClusterIP
     port: 6379
     targetPort: 6379
+    protocol: TCP
   - name: redis-insight
-    type: ClusterIP
     port: 8001
     targetPort: 8001
+    protocol: TCP
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -58,10 +58,12 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   # HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  LANGCHAIN_TRACING_V2: false
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
+          {{- if not .Values.noProbe }}
           startupProbe:
             exec:
               command:
@@ -60,14 +61,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 120
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -59,6 +59,8 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: false
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"

--- a/helm-charts/common/speecht5/gaudi-values.yaml
+++ b/helm-charts/common/speecht5/gaudi-values.yaml
@@ -7,8 +7,8 @@
 
 replicaCount: 1
 
-  # TTS_MODEL_PATH: "microsoft/speecht5_tts"
-  # VOCODE_MODEL: "microsoft/speecht5_hifigan"
+TTS_MODEL_PATH: "microsoft/speecht5_tts"
+#VOCODE_MODEL: "microsoft/speecht5_hifigan"
 
 image:
   repository: opea/speecht5-gaudi:latest
@@ -60,7 +60,7 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/speecht5/values.yaml
+++ b/helm-charts/common/speecht5/values.yaml
@@ -7,8 +7,8 @@
 
 replicaCount: 1
 
-  # TTS_MODEL_PATH: "microsoft/speecht5_tts"
-  # VOCODE_MODEL: "microsoft/speecht5_hifigan"
+TTS_MODEL_PATH: "microsoft/speecht5_tts"
+#VOCODE_MODEL: "microsoft/speecht5_hifigan"
 
 image:
   repository: opea/speecht5:latest
@@ -60,7 +60,7 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tei/gaudi-values.yaml
+++ b/helm-charts/common/tei/gaudi-values.yaml
@@ -60,9 +60,9 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tei/gaudi-values.yaml
+++ b/helm-charts/common/tei/gaudi-values.yaml
@@ -1,0 +1,68 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for tei.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+port: 2081
+shmSize: 1Gi
+EMBEDDING_MODEL_ID: "BAAI/bge-base-en-v1.5"
+image:
+  repository: opea/tei-gaudi
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+
+resources:
+  limits:
+    habana.ai/gaudi: 1
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  http_proxy:
+  https_proxy:
+  no_proxy:
+  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
+  # comment out modeluseHostPath if you want to download the model from huggingface
+  modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -58,9 +58,9 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -58,9 +58,9 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/tgi/gaudi-values.yaml
+++ b/helm-charts/common/tgi/gaudi-values.yaml
@@ -52,9 +52,9 @@ LLM_MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
 # LLM_MODEL_ID: /data/Magicoder-S-DS-6.7B
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -60,9 +60,9 @@ LLM_MODEL_ID: bigscience/bloom-560m
 # LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
   # comment out modeluseHostPath if you want to download the model from huggingface

--- a/helm-charts/common/tts/values.yaml
+++ b/helm-charts/common/tts/values.yaml
@@ -59,6 +59,6 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/helm-charts/common/web-retriever/templates/deployment.yaml
+++ b/helm-charts/common/web-retriever/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: tmp
+          {{- if not .Values.noProbe }}
           startupProbe:
             exec:
               command:
@@ -60,14 +61,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 120
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: 7000
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm-charts/common/web-retriever/values.yaml
+++ b/helm-charts/common/web-retriever/values.yaml
@@ -61,6 +61,6 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/helm-charts/common/whisper/gaudi-values.yaml
+++ b/helm-charts/common/whisper/gaudi-values.yaml
@@ -59,7 +59,7 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/whisper/values.yaml
+++ b/helm-charts/common/whisper/values.yaml
@@ -59,7 +59,7 @@ tolerations: []
 affinity: {}
 
 global:
-  http_proxy:
-  https_proxy:
-  no_proxy:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
   modelUseHostPath: /mnt/opea-models

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -7,32 +7,27 @@
 ## Deploy On Xeon
 
 ```
-cd GenAIInfra/manifests/${component}/xeon
+cd GenAIInfra/manifests/common
+export component=<component>
 export HUGGINGFACEHUB_API_TOKEN="YourOwnToken"
-sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" *.yaml
-kubectl apply -f *.yaml
+sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" ${component}.yaml
+kubectl apply -f ${component}.yaml
 ```
 
 ## Deploy On Gaudi
 
 ```
-cd GenAIInfra/manifests/${component}/gaudi
+cd GenAIInfra/manifests/common
+export component=<component>
 export HUGGINGFACEHUB_API_TOKEN="YourOwnToken"
-sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" *.yaml
-kubectl apply -f *.yaml
+# if there is a manifest file named after ${component}_gaudi.yaml
+sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" ${component}_gaudi.yaml
+kubectl apply -f ${component}_gaudi.yaml
+# else apply the xeon manifest file
+sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" ${component}.yaml
+kubectl apply -f ${component}.yaml
 ```
 
 ## Generate the manifest file from helm chart
 
-Refer to update_manifests.sh for details.
-
-Here is the one example:
-
-```
-cd GenAIInfra/manifests/CodeTrans
-export HF_TOKEN="insert-your-huggingface-token-here"
-export MODELDIR="/mnt"
-helm template codetrans ../../helm-charts/common/llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HF_TOKEN} --set image.repository="opea/llm-tgi:latest" --set tgi.volume=${MODELDIR} --set tgi.LLM_MODEL_ID="HuggingFaceH4/mistral-7b-grok" --values ../../helm-charts/common/llm-uservice/values.yaml > xeon/llm.yaml
-helm template codetrans ../../helm-charts/common/llm-uservice --set global.HUGGINGFACEHUB_API_TOKEN=${HF_TOKEN} --set image.repository="opea/llm-tgi:latest" --set tgi.volume=${MODELDIR} --set tgi.LLM_MODEL_ID="HuggingFaceH4/mistral-7b-grok" --values ../../helm-charts/common/llm-uservice/gaudi-values.yaml > gaudi/llm.yaml
-
-```
+Refer to [update_manifests.sh](update_manifests.sh) for details.

--- a/manifests/common/asr.yaml
+++ b/manifests/common/asr.yaml
@@ -1,0 +1,106 @@
+---
+# Source: asr/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: asr-config
+  labels:
+    helm.sh/chart: asr-0.8.0
+    app.kubernetes.io/name: asr
+    app.kubernetes.io/instance: asr
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  ASR_ENDPOINT: "http://asr-whisper:7066"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+---
+# Source: asr/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: asr
+  labels:
+    helm.sh/chart: asr-0.8.0
+    app.kubernetes.io/name: asr
+    app.kubernetes.io/instance: asr
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9099
+      targetPort: 9099
+      protocol: TCP
+      name: asr
+  selector:
+    app.kubernetes.io/name: asr
+    app.kubernetes.io/instance: asr
+---
+# Source: asr/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: asr
+  labels:
+    helm.sh/chart: asr-0.8.0
+    app.kubernetes.io/name: asr
+    app.kubernetes.io/instance: asr
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: asr
+      app.kubernetes.io/instance: asr
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: asr
+        app.kubernetes.io/instance: asr
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: asr
+          envFrom:
+            - configMapRef:
+                name: asr-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/asr:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: asr
+              containerPort: 9099
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/data-prep.yaml
+++ b/manifests/common/data-prep.yaml
@@ -1,0 +1,113 @@
+---
+# Source: data-prep/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-prep-config
+  labels:
+    helm.sh/chart: data-prep-0.8.0
+    app.kubernetes.io/name: data-prep
+    app.kubernetes.io/instance: data-prep
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TEI_ENDPOINT: "http://data-prep-tei"
+  REDIS_URL: "redis://data-prep-redis-vector-db:6379"
+  INDEX_NAME: "rag-redis"
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  HF_HOME: "/tmp/.cache/huggingface"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  LANGCHAIN_PROJECT: "opea-dataprep-service"
+---
+# Source: data-prep/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-prep
+  labels:
+    helm.sh/chart: data-prep-0.8.0
+    app.kubernetes.io/name: data-prep
+    app.kubernetes.io/instance: data-prep
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6007
+      targetPort: 6007
+      protocol: TCP
+      name: data-prep
+  selector:
+    app.kubernetes.io/name: data-prep
+    app.kubernetes.io/instance: data-prep
+---
+# Source: data-prep/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-prep
+  labels:
+    helm.sh/chart: data-prep-0.8.0
+    app.kubernetes.io/name: data-prep
+    app.kubernetes.io/instance: data-prep
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: data-prep
+      app.kubernetes.io/instance: data-prep
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: data-prep
+        app.kubernetes.io/instance: data-prep
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: data-prep
+          envFrom:
+            - configMapRef:
+                name: data-prep-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/dataprep-redis:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: data-prep
+              containerPort: 6007
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/docsum-llm-uservice.yaml
+++ b/manifests/common/docsum-llm-uservice.yaml
@@ -1,0 +1,111 @@
+---
+# Source: llm-uservice/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docsum-llm-uservice-config
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: docsum
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TGI_LLM_ENDPOINT: "http://docsum-tgi"
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  HF_HOME: "/tmp/.cache/huggingface"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: insert-your-langchain-key-here
+  LANGCHAIN_PROJECT: "opea-llm-uservice"
+---
+# Source: llm-uservice/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: docsum-llm-uservice
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: docsum
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: llm-uservice
+  selector:
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: docsum
+---
+# Source: llm-uservice/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docsum-llm-uservice
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: docsum
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llm-uservice
+      app.kubernetes.io/instance: docsum
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llm-uservice
+        app.kubernetes.io/instance: docsum
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: docsum
+          envFrom:
+            - configMapRef:
+                name: docsum-llm-uservice-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/llm-docsum-tgi:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: llm-uservice
+              containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/embedding-usvc.yaml
+++ b/manifests/common/embedding-usvc.yaml
@@ -1,0 +1,109 @@
+---
+# Source: embedding-usvc/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: embedding-usvc-config
+  labels:
+    helm.sh/chart: embedding-usvc-0.8.0
+    app.kubernetes.io/name: embedding-usvc
+    app.kubernetes.io/instance: embedding-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TEI_EMBEDDING_ENDPOINT: "http://embedding-usvc-tei"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: insert-your-langchain-key-here
+  LANGCHAIN_PROJECT: "opea-embedding-service"
+---
+# Source: embedding-usvc/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: embedding-usvc
+  labels:
+    helm.sh/chart: embedding-usvc-0.8.0
+    app.kubernetes.io/name: embedding-usvc
+    app.kubernetes.io/instance: embedding-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6000
+      targetPort: 6000
+      protocol: TCP
+      name: embedding-usvc
+  selector:
+    app.kubernetes.io/name: embedding-usvc
+    app.kubernetes.io/instance: embedding-usvc
+---
+# Source: embedding-usvc/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embedding-usvc
+  labels:
+    helm.sh/chart: embedding-usvc-0.8.0
+    app.kubernetes.io/name: embedding-usvc
+    app.kubernetes.io/instance: embedding-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: embedding-usvc
+      app.kubernetes.io/instance: embedding-usvc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: embedding-usvc
+        app.kubernetes.io/instance: embedding-usvc
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: embedding-usvc
+          envFrom:
+            - configMapRef:
+                name: embedding-usvc-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/embedding-tei:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: embedding-usvc
+              containerPort: 6000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/llm-uservice.yaml
+++ b/manifests/common/llm-uservice.yaml
@@ -1,0 +1,111 @@
+---
+# Source: llm-uservice/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-uservice-config
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: llm-uservice
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TGI_LLM_ENDPOINT: "http://llm-uservice-tgi"
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  HF_HOME: "/tmp/.cache/huggingface"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: insert-your-langchain-key-here
+  LANGCHAIN_PROJECT: "opea-llm-uservice"
+---
+# Source: llm-uservice/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-uservice
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: llm-uservice
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: llm-uservice
+  selector:
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: llm-uservice
+---
+# Source: llm-uservice/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-uservice
+  labels:
+    helm.sh/chart: llm-uservice-0.8.0
+    app.kubernetes.io/name: llm-uservice
+    app.kubernetes.io/instance: llm-uservice
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llm-uservice
+      app.kubernetes.io/instance: llm-uservice
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llm-uservice
+        app.kubernetes.io/instance: llm-uservice
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: llm-uservice
+          envFrom:
+            - configMapRef:
+                name: llm-uservice-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/llm-tgi:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: llm-uservice
+              containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/redis-vector-db.yaml
+++ b/manifests/common/redis-vector-db.yaml
@@ -1,0 +1,101 @@
+---
+# Source: redis-vector-db/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-vector-db
+  labels:
+    helm.sh/chart: redis-vector-db-0.8.0
+    app.kubernetes.io/name: redis-vector-db
+    app.kubernetes.io/instance: redis-vector-db
+    app.kubernetes.io/version: "7.2.0-v9"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+      - port: 6379
+        targetPort: 6379
+        protocol: TCP
+        name: redis-service
+      - port: 8001
+        targetPort: 8001
+        protocol: TCP
+        name: redis-insight
+  selector:
+    app.kubernetes.io/name: redis-vector-db
+    app.kubernetes.io/instance: redis-vector-db
+---
+# Source: redis-vector-db/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-vector-db
+  labels:
+    helm.sh/chart: redis-vector-db-0.8.0
+    app.kubernetes.io/name: redis-vector-db
+    app.kubernetes.io/instance: redis-vector-db
+    app.kubernetes.io/version: "7.2.0-v9"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis-vector-db
+      app.kubernetes.io/instance: redis-vector-db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis-vector-db
+        app.kubernetes.io/instance: redis-vector-db
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: redis-vector-db
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "redis/redis-stack:7.2.0-v9"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: data-volume
+            - mountPath: /redisinsight
+              name: redisinsight-volume
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: redis-service
+              containerPort: 6379
+              protocol: TCP
+            - name: redis-insight
+              containerPort: 8001
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 6379 # Probe the Redis port
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 120
+          resources:
+            {}
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+        - name: redisinsight-volume
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/reranking-usvc.yaml
+++ b/manifests/common/reranking-usvc.yaml
@@ -1,0 +1,109 @@
+---
+# Source: reranking-usvc/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reranking-usvc-config
+  labels:
+    helm.sh/chart: reranking-usvc-0.8.0
+    app.kubernetes.io/name: reranking-usvc
+    app.kubernetes.io/instance: reranking-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TEI_RERANKING_ENDPOINT: "http://reranking-usvc-teirerank"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  LANGCHAIN_PROJECT: "opea-reranking-service"
+---
+# Source: reranking-usvc/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: reranking-usvc
+  labels:
+    helm.sh/chart: reranking-usvc-0.8.0
+    app.kubernetes.io/name: reranking-usvc
+    app.kubernetes.io/instance: reranking-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: reranking-usvc
+  selector:
+    app.kubernetes.io/name: reranking-usvc
+    app.kubernetes.io/instance: reranking-usvc
+---
+# Source: reranking-usvc/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reranking-usvc
+  labels:
+    helm.sh/chart: reranking-usvc-0.8.0
+    app.kubernetes.io/name: reranking-usvc
+    app.kubernetes.io/instance: reranking-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reranking-usvc
+      app.kubernetes.io/instance: reranking-usvc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reranking-usvc
+        app.kubernetes.io/instance: reranking-usvc
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: reranking-usvc
+          envFrom:
+            - configMapRef:
+                name: reranking-usvc-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/reranking-tei:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: reranking-usvc
+              containerPort: 8000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/retriever-usvc.yaml
+++ b/manifests/common/retriever-usvc.yaml
@@ -1,0 +1,113 @@
+---
+# Source: retriever-usvc/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: retriever-usvc-config
+  labels:
+    helm.sh/chart: retriever-usvc-0.8.0
+    app.kubernetes.io/name: retriever-usvc
+    app.kubernetes.io/instance: retriever-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TEI_EMBEDDING_ENDPOINT: "http://retriever-usvc-tei"
+  REDIS_URL: "redis://retriever-usvc-redis-vector-db:6379"
+  INDEX_NAME: "rag-redis"
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  LANGCHAIN_TRACING_V2: "false"
+  LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  LANGCHAIN_PROJECT: "opea-retriever-service"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: retriever-usvc/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: retriever-usvc
+  labels:
+    helm.sh/chart: retriever-usvc-0.8.0
+    app.kubernetes.io/name: retriever-usvc
+    app.kubernetes.io/instance: retriever-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7000
+      targetPort: 7000
+      protocol: TCP
+      name: retriever-usvc
+  selector:
+    app.kubernetes.io/name: retriever-usvc
+    app.kubernetes.io/instance: retriever-usvc
+---
+# Source: retriever-usvc/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: retriever-usvc
+  labels:
+    helm.sh/chart: retriever-usvc-0.8.0
+    app.kubernetes.io/name: retriever-usvc
+    app.kubernetes.io/instance: retriever-usvc
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: retriever-usvc
+      app.kubernetes.io/instance: retriever-usvc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: retriever-usvc
+        app.kubernetes.io/instance: retriever-usvc
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: retriever-usvc
+          envFrom:
+            - configMapRef:
+                name: retriever-usvc-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/retriever-redis:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: retriever-usvc
+              containerPort: 7000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/speecht5.yaml
+++ b/manifests/common/speecht5.yaml
@@ -1,0 +1,115 @@
+---
+# Source: speecht5/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: speecht5-config
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  # TTS_MODEL_PATH: "microsoft/speecht5_tts"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACE_HUB_CACHE: "/data"
+---
+# Source: speecht5/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: speecht5
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7055
+      targetPort: 7055
+      protocol: TCP
+      name: speecht5
+  selector:
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+---
+# Source: speecht5/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: speecht5
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: speecht5
+      app.kubernetes.io/instance: speecht5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: speecht5
+        app.kubernetes.io/instance: speecht5
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: speecht5
+          envFrom:
+            - configMapRef:
+                name: speecht5-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/speecht5:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: speecht5
+              containerPort: 7055
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/speecht5_gaudi.yaml
+++ b/manifests/common/speecht5_gaudi.yaml
@@ -1,0 +1,115 @@
+---
+# Source: speecht5/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: speecht5-config
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  # TTS_MODEL_PATH: "microsoft/speecht5_tts"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACE_HUB_CACHE: "/data"
+---
+# Source: speecht5/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: speecht5
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7055
+      targetPort: 7055
+      protocol: TCP
+      name: speecht5
+  selector:
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+---
+# Source: speecht5/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: speecht5
+  labels:
+    helm.sh/chart: speecht5-0.8.0
+    app.kubernetes.io/name: speecht5
+    app.kubernetes.io/instance: speecht5
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: speecht5
+      app.kubernetes.io/instance: speecht5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: speecht5
+        app.kubernetes.io/instance: speecht5
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: speecht5
+          envFrom:
+            - configMapRef:
+                name: speecht5-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/speecht5-gaudi:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: speecht5
+              containerPort: 7055
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/tei.yaml
+++ b/manifests/common/tei.yaml
@@ -1,0 +1,114 @@
+---
+# Source: tei/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tei-config
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  MODEL_ID: "BAAI/bge-base-en-v1.5"
+  PORT: "2081"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: tei/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tei
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 2081
+      protocol: TCP
+      name: tei
+  selector:
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+---
+# Source: tei/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tei
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tei
+      app.kubernetes.io/instance: tei
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tei
+        app.kubernetes.io/instance: tei
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: tei
+          envFrom:
+            - configMapRef:
+                name: tei-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            {}
+          image: "ghcr.io/huggingface/text-embeddings-inference:cpu-1.2"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: http
+              containerPort: 2081
+              protocol: TCP
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/tei_gaudi.yaml
+++ b/manifests/common/tei_gaudi.yaml
@@ -1,0 +1,115 @@
+---
+# Source: tei/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tei-config
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  MODEL_ID: "BAAI/bge-base-en-v1.5"
+  PORT: "2081"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: tei/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tei
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 2081
+      protocol: TCP
+      name: tei
+  selector:
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+---
+# Source: tei/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tei
+  labels:
+    helm.sh/chart: tei-0.8.0
+    app.kubernetes.io/name: tei
+    app.kubernetes.io/instance: tei
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tei
+      app.kubernetes.io/instance: tei
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tei
+        app.kubernetes.io/instance: tei
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: tei
+          envFrom:
+            - configMapRef:
+                name: tei-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            {}
+          image: "opea/tei-gaudi:latest"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: http
+              containerPort: 2081
+              protocol: TCP
+          resources:
+            limits:
+              habana.ai/gaudi: 1
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/teirerank.yaml
+++ b/manifests/common/teirerank.yaml
@@ -1,0 +1,114 @@
+---
+# Source: teirerank/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: teirerank-config
+  labels:
+    helm.sh/chart: teirerank-0.8.0
+    app.kubernetes.io/name: teirerank
+    app.kubernetes.io/instance: teirerank
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+data:
+  MODEL_ID: "BAAI/bge-reranker-base"
+  PORT: "2082"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: teirerank/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: teirerank
+  labels:
+    helm.sh/chart: teirerank-0.8.0
+    app.kubernetes.io/name: teirerank
+    app.kubernetes.io/instance: teirerank
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 2082
+      protocol: TCP
+      name: teirerank
+  selector:
+    app.kubernetes.io/name: teirerank
+    app.kubernetes.io/instance: teirerank
+---
+# Source: teirerank/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teirerank
+  labels:
+    helm.sh/chart: teirerank-0.8.0
+    app.kubernetes.io/name: teirerank
+    app.kubernetes.io/instance: teirerank
+    app.kubernetes.io/version: "1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: teirerank
+      app.kubernetes.io/instance: teirerank
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: teirerank
+        app.kubernetes.io/instance: teirerank
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: teirerank
+          envFrom:
+            - configMapRef:
+                name: teirerank-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            {}
+          image: "ghcr.io/huggingface/text-embeddings-inference:cpu-1.2"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: http
+              containerPort: 2082
+              protocol: TCP
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/tgi.yaml
+++ b/manifests/common/tgi.yaml
@@ -1,0 +1,113 @@
+---
+# Source: tgi/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tgi-config
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+data:
+  MODEL_ID: "bigscience/bloom-560m"
+  PORT: "2080"
+  HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+  HF_TOKEN: "insert-your-huggingface-token-here"
+  MAX_INPUT_TOKENS: "1024"
+  MAX_TOTAL_TOKENS: "4096"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HABANA_LOGS: "/tmp/habana_logs"
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: tgi/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tgi
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 2080
+      protocol: TCP
+      name: tgi
+  selector:
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+---
+# Source: tgi/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tgi
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tgi
+      app.kubernetes.io/instance: tgi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tgi
+        app.kubernetes.io/instance: tgi
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: tgi
+          envFrom:
+            - configMapRef:
+                name: tgi-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            {}
+          image: "ghcr.io/huggingface/text-generation-inference:1.4"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: http
+              containerPort: 2080
+              protocol: TCP
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/tgi_gaudi.yaml
+++ b/manifests/common/tgi_gaudi.yaml
@@ -1,0 +1,114 @@
+---
+# Source: tgi/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tgi-config
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+data:
+  MODEL_ID: "ise-uiuc/Magicoder-S-DS-6.7B"
+  PORT: "2080"
+  HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+  HF_TOKEN: "insert-your-huggingface-token-here"
+  MAX_INPUT_TOKENS: "1024"
+  MAX_TOTAL_TOKENS: "4096"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HABANA_LOGS: "/tmp/habana_logs"
+  NUMBA_CACHE_DIR: "/tmp"
+  TRANSFORMERS_CACHE: "/tmp/transformers_cache"
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: tgi/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tgi
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 2080
+      protocol: TCP
+      name: tgi
+  selector:
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+---
+# Source: tgi/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tgi
+  labels:
+    helm.sh/chart: tgi-0.8.0
+    app.kubernetes.io/name: tgi
+    app.kubernetes.io/instance: tgi
+    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tgi
+      app.kubernetes.io/instance: tgi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tgi
+        app.kubernetes.io/instance: tgi
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: tgi
+          envFrom:
+            - configMapRef:
+                name: tgi-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            {}
+          image: "ghcr.io/huggingface/tgi-gaudi:1.2.1"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: http
+              containerPort: 2080
+              protocol: TCP
+          resources:
+            limits:
+              habana.ai/gaudi: 1
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/tts.yaml
+++ b/manifests/common/tts.yaml
@@ -1,0 +1,106 @@
+---
+# Source: tts/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tts-config
+  labels:
+    helm.sh/chart: tts-0.8.0
+    app.kubernetes.io/name: tts
+    app.kubernetes.io/instance: tts
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TTS_ENDPOINT: "http://tts-speecht5:7055"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+---
+# Source: tts/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tts
+  labels:
+    helm.sh/chart: tts-0.8.0
+    app.kubernetes.io/name: tts
+    app.kubernetes.io/instance: tts
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9088
+      targetPort: 9088
+      protocol: TCP
+      name: tts
+  selector:
+    app.kubernetes.io/name: tts
+    app.kubernetes.io/instance: tts
+---
+# Source: tts/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tts
+  labels:
+    helm.sh/chart: tts-0.8.0
+    app.kubernetes.io/name: tts
+    app.kubernetes.io/instance: tts
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tts
+      app.kubernetes.io/instance: tts
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tts
+        app.kubernetes.io/instance: tts
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: tts
+          envFrom:
+            - configMapRef:
+                name: tts-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/tts:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: tts
+              containerPort: 9088
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/web-retriever.yaml
+++ b/manifests/common/web-retriever.yaml
@@ -1,0 +1,110 @@
+---
+# Source: web-retriever/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-retriever-config
+  labels:
+    helm.sh/chart: web-retriever-0.8.0
+    app.kubernetes.io/name: web-retriever
+    app.kubernetes.io/instance: web-retriever
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TEI_EMBEDDING_ENDPOINT: "http://web-retriever-tei"
+  GOOGLE_API_KEY: ""
+  GOOGLE_CSE_ID: ""
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HF_HOME: "/tmp/.cache/huggingface"
+---
+# Source: web-retriever/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-retriever
+  labels:
+    helm.sh/chart: web-retriever-0.8.0
+    app.kubernetes.io/name: web-retriever
+    app.kubernetes.io/instance: web-retriever
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7077
+      targetPort: 7077
+      protocol: TCP
+      name: web-retriever
+  selector:
+    app.kubernetes.io/name: web-retriever
+    app.kubernetes.io/instance: web-retriever
+---
+# Source: web-retriever/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-retriever
+  labels:
+    helm.sh/chart: web-retriever-0.8.0
+    app.kubernetes.io/name: web-retriever
+    app.kubernetes.io/instance: web-retriever
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web-retriever
+      app.kubernetes.io/instance: web-retriever
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web-retriever
+        app.kubernetes.io/instance: web-retriever
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: web-retriever
+          envFrom:
+            - configMapRef:
+                name: web-retriever-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/web-retriever-chroma:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: web-retriever
+              containerPort: 7077
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/whisper.yaml
+++ b/manifests/common/whisper.yaml
@@ -1,0 +1,115 @@
+---
+# Source: whisper/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whisper-config
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  ASR_MODEL_PATH: "openai/whisper-small"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACE_HUB_CACHE: "/data"
+---
+# Source: whisper/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: whisper
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7066
+      targetPort: 7066
+      protocol: TCP
+      name: whisper
+  selector:
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+---
+# Source: whisper/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisper
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: whisper
+      app.kubernetes.io/instance: whisper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: whisper
+        app.kubernetes.io/instance: whisper
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: whisper
+          envFrom:
+            - configMapRef:
+                name: whisper-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/whisper:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: whisper
+              containerPort: 7066
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/common/whisper_gaudi.yaml
+++ b/manifests/common/whisper_gaudi.yaml
@@ -1,0 +1,115 @@
+---
+# Source: whisper/templates/configmap.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whisper-config
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
+  ASR_MODEL_PATH: "openai/whisper-small"
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""
+  HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACE_HUB_CACHE: "/data"
+---
+# Source: whisper/templates/service.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: whisper
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7066
+      targetPort: 7066
+      protocol: TCP
+      name: whisper
+  selector:
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+---
+# Source: whisper/templates/deployment.yaml
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisper
+  labels:
+    helm.sh/chart: whisper-0.8.0
+    app.kubernetes.io/name: whisper
+    app.kubernetes.io/instance: whisper
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: whisper
+      app.kubernetes.io/instance: whisper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: whisper
+        app.kubernetes.io/instance: whisper
+    spec:
+      securityContext:
+        {}
+      containers:
+        - name: whisper
+          envFrom:
+            - configMapRef:
+                name: whisper-config
+            - configMapRef:
+                name: extra-env-config
+                optional: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: "opea/whisper-gaudi:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: whisper
+              containerPort: 7066
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: model-volume
+            - mountPath: /tmp
+              name: tmp
+          resources:
+            {}
+      volumes:
+        - name: model-volume
+          hostPath:
+            path: /mnt/opea-models
+            type: Directory
+        - name: tmp
+          emptyDir: {}

--- a/manifests/update_manifests.sh
+++ b/manifests/update_manifests.sh
@@ -4,27 +4,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CUR_DIR=$(cd $(dirname "$0") && pwd)
+OUTPUTDIR=${CUR_DIR}/common
 
 #
-# generate_yaml llm-uservice
+# generate_yaml <chart> <outputdir>
 #
 function generate_yaml {
   chart=$1
-  mkdir -p $chart/xeon
-  helm template $chart ../helm-charts/common/$chart --values ../helm-charts/common/$chart/values.yaml > $chart/xeon/$chart.yaml
-  mkdir -p $chart/gaudi
+  outputdir=$2
+
+  helm template $chart ../helm-charts/common/$chart --skip-tests --values ../helm-charts/common/$chart/values.yaml --set global.extraEnvConfig=extra-env-config,noProbe=true > ${outputdir}/$chart.yaml
   if [ -f ../helm-charts/common/$chart/gaudi-values.yaml ]; then
-    helm template $chart ../helm-charts/common/$chart --values ../helm-charts/common/$chart/gaudi-values.yaml > $chart/gaudi/$chart.yaml
-  else
-    helm template $chart ../helm-charts/common/$chart --values ../helm-charts/common/$chart/values.yaml > $chart/gaudi/$chart.yaml
+    helm template $chart ../helm-charts/common/$chart --skip-tests --values ../helm-charts/common/$chart/gaudi-values.yaml --set global.extraEnvConfig=extra-env-config,noProbe=true  > ${outputdir}/${chart}_gaudi.yaml
   fi
 }
 
-# echo $CUR_DIR
+mkdir -p $OUTPUTDIR
 cd $CUR_DIR
 for chart in ${CUR_DIR}/../helm-charts/common/*
 do
 	chartname=`basename $chart`
 	echo "Update manifest for $chartname..."
-	generate_yaml $chartname
+	generate_yaml $chartname $OUTPUTDIR
 done
+
+# we need special version of docsum-llm-uservice
+echo "Update manifest for docsum-llm-uservice..."
+helm template docsum ../helm-charts/common/llm-uservice --skip-tests --set global.extraEnvConfig=extra-env-config,noProbe=true,image.repository=opea/llm-docsum-tgi:latest > ${OUTPUTDIR}/docsum-llm-uservice.yaml


### PR DESCRIPTION
## Description

Change how component level manifests are generated for GMC

- Move all generated component level manifests into a common flat directory
- Disable k8s probes for GMC manifest
- Add tei-gaudi support
- Add generated component manifest files

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

n/a

## Tests

n/a
