### PR TITLE
Upgrade tgi version

### DIFF
--- a/helm-charts/common/tgi/Chart.yaml
+++ b/helm-charts/common/tgi/Chart.yaml
@@ -7,4 +7,4 @@ description: The Helm chart for HuggingFace Text Generation Inference Server
 type: application
 version: 0.8.0
 # The HF TGI version
-appVersion: "1.4"
+appVersion: "2.1.0"

--- a/helm-charts/common/tgi/gaudi-values.yaml
+++ b/helm-charts/common/tgi/gaudi-values.yaml
@@ -13,7 +13,7 @@ image:
   repository: ghcr.io/huggingface/tgi-gaudi
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.2.1"
+  tag: "2.0.1"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -48,8 +48,7 @@ tolerations: []
 
 affinity: {}
 
-LLM_MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
-# LLM_MODEL_ID: /data/Magicoder-S-DS-6.7B
+LLM_MODEL_ID: Intel/neural-chat-7b-v3-3
 
 global:
   http_proxy: ""

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: ghcr.io/huggingface/text-generation-inference
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.4"
+  tag: "2.1.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -56,8 +56,7 @@ tolerations: []
 
 affinity: {}
 
-LLM_MODEL_ID: bigscience/bloom-560m
-# LLM_MODEL_ID: /data/OpenCodeInterpreter-DS-6.7B
+LLM_MODEL_ID: Intel/neural-chat-7b-v3-3
 
 global:
   http_proxy: ""

--- a/helm-charts/update_dependency.sh
+++ b/helm-charts/update_dependency.sh
@@ -7,5 +7,7 @@ UPD_DIR=$(cd $(dirname "$0") && pwd)
 for chart in ${UPD_DIR}/common/*
 do
 	echo "Update dependency for `basename $chart`..."
+        rm -f ${chart}/Chart.lock
+        rm -rf ${chart}/charts/
 	helm dependency update ${chart}
 done

--- a/manifests/common/tgi.yaml
+++ b/manifests/common/tgi.yaml
@@ -11,10 +11,10 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  MODEL_ID: "bigscience/bloom-560m"
+  MODEL_ID: "Intel/neural-chat-7b-v3-3"
   PORT: "2080"
   HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
   HF_TOKEN: "insert-your-huggingface-token-here"
@@ -40,7 +40,7 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -65,7 +65,7 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -91,7 +91,7 @@ spec:
                 optional: true
           securityContext:
             {}
-          image: "ghcr.io/huggingface/text-generation-inference:1.4"
+          image: "ghcr.io/huggingface/text-generation-inference:2.1.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data

--- a/manifests/common/tgi_gaudi.yaml
+++ b/manifests/common/tgi_gaudi.yaml
@@ -11,10 +11,10 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 data:
-  MODEL_ID: "ise-uiuc/Magicoder-S-DS-6.7B"
+  MODEL_ID: "Intel/neural-chat-7b-v3-3"
   PORT: "2080"
   HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
   HF_TOKEN: "insert-your-huggingface-token-here"
@@ -40,7 +40,7 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -65,7 +65,7 @@ metadata:
     helm.sh/chart: tgi-0.8.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
-    app.kubernetes.io/version: "1.4"
+    app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -91,7 +91,7 @@ spec:
                 optional: true
           securityContext:
             {}
-          image: "ghcr.io/huggingface/tgi-gaudi:1.2.1"
+          image: "ghcr.io/huggingface/tgi-gaudi:2.0.1"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data


### PR DESCRIPTION
## Description

- Upgrade tgi-gaudi to version 2.0.1 which works with habana sw stack 1.16.x.
- Upgrade tgi to version 2.1.0
- change default model to Intel/neural-chat-7b-v3-3

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a

## Tests

Describe the tests that you ran to verify your changes.
