### PR TITLE
Add new example of searchQnA on both xeon and gaudi

### DIFF
--- a/microservices-connector/config/samples/searchQnA_gaudi.yaml
+++ b/microservices-connector/config/samples/searchQnA_gaudi.yaml
@@ -1,0 +1,63 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: gmc.opea.io/v1alpha3
+kind: GMConnector
+metadata:
+  labels:
+    app.kubernetes.io/name: gmconnector
+    app.kubernetes.io/managed-by: kustomize
+    gmc/platform: gaudi
+  name: searchqa
+  namespace: searchqa
+spec:
+  routerConfig:
+    name: router
+    serviceName: router-service
+  nodes:
+    root:
+      routerType: Sequence
+      steps:
+      - name: Embedding
+        internalService:
+          serviceName: embedding-svc
+          config:
+            endpoint: /v1/embeddings
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-gaudi-svc
+      - name: TeiEmbeddingGaudi
+        internalService:
+          serviceName: tei-embedding-gaudi-svc
+          isDownstreamService: true
+      - name: WebRetriever
+        data: $response
+        internalService:
+          serviceName: web-retriever-svc
+          config:
+            endpoint: /v1/web_retrieval
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-gaudi-svc
+      - name: Reranking
+        data: $response
+        internalService:
+          serviceName: reranking-svc
+          config:
+            endpoint: /v1/reranking
+            TEI_RERANKING_ENDPOINT: tei-reranking-svc
+      - name: TeiReranking
+        internalService:
+          serviceName: tei-reranking-svc
+          config:
+            endpoint: /rerank
+          isDownstreamService: true
+      - name: Llm
+        data: $response
+        internalService:
+          serviceName: llm-svc
+          config:
+            endpoint: /v1/chat/completions
+            TGI_LLM_ENDPOINT: tgi-gaudi-svc
+      - name: TgiGaudi
+        internalService:
+          serviceName: tgi-gaudi-svc
+          config:
+            endpoint: /generate
+          isDownstreamService: true

--- a/microservices-connector/config/samples/searchQnA_xeon.yaml
+++ b/microservices-connector/config/samples/searchQnA_xeon.yaml
@@ -1,0 +1,63 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: gmc.opea.io/v1alpha3
+kind: GMConnector
+metadata:
+  labels:
+    app.kubernetes.io/name: gmconnector
+    app.kubernetes.io/managed-by: kustomize
+    gmc/platform: xeon
+  name: searchqa
+  namespace: searchqa
+spec:
+  routerConfig:
+    name: router
+    serviceName: router-service
+  nodes:
+    root:
+      routerType: Sequence
+      steps:
+      - name: Embedding
+        internalService:
+          serviceName: embedding-svc
+          config:
+            endpoint: /v1/embeddings
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-svc
+      - name: TeiEmbedding
+        internalService:
+          serviceName: tei-embedding-svc
+          isDownstreamService: true
+      - name: WebRetriever
+        data: $response
+        internalService:
+          serviceName: web-retriever-svc
+          config:
+            endpoint: /v1/web_retrieval
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-svc
+      - name: Reranking
+        data: $response
+        internalService:
+          serviceName: reranking-svc
+          config:
+            endpoint: /v1/reranking
+            TEI_RERANKING_ENDPOINT: tei-reranking-svc
+      - name: TeiReranking
+        internalService:
+          serviceName: tei-reranking-svc
+          config:
+            endpoint: /rerank
+          isDownstreamService: true
+      - name: Llm
+        data: $response
+        internalService:
+          serviceName: llm-svc
+          config:
+            endpoint: /v1/chat/completions
+            TGI_LLM_ENDPOINT: tgi-service-m
+      - name: Tgi
+        internalService:
+          serviceName: tgi-service-m
+          config:
+            endpoint: /generate
+          isDownstreamService: true


### PR DESCRIPTION
## Description

Add new example of searchQnA on both xeon and gaudi.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`.

## Tests

```sh
root@satg-opea-4node-1:/home/huailong# kubectl get svc -n searchqa     
NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
embedding-svc       ClusterIP   172.21.58.179    <none>        6000/TCP   100m
llm-svc             ClusterIP   172.21.127.255   <none>        9000/TCP   99m
reranking-svc       ClusterIP   172.21.93.122    <none>        8000/TCP   99m
router-service      ClusterIP   172.21.129.137   <none>        8080/TCP   99m
tei-embedding-svc   ClusterIP   172.21.73.33     <none>        80/TCP     99m
tei-reranking-svc   ClusterIP   172.21.159.247   <none>        80/TCP     99m
tgi-service-m       ClusterIP   172.21.191.84    <none>        80/TCP     99m
web-retriever-svc   ClusterIP   172.21.31.70     <none>        7077/TCP   99m
root@satg-opea-4node-1:/home/huailong# 
root@satg-opea-4node-1:/home/huailong# kubectl get deployment -n searchqa
NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
embedding-svc-deployment       1/1     1            1           100m
llm-svc-deployment             1/1     1            1           99m
reranking-svc-deployment       1/1     1            1           99m
router-server                  1/1     1            1           99m
tei-embedding-svc-deployment   1/1     1            1           100m
tei-reranking-svc-deployment   1/1     1            1           99m
tgi-service-m-deployment       1/1     1            1           99m
web-retriever-svc-deployment   1/1     1            1           100m
root@satg-opea-4node-1:/home/huailong#
root@satg-opea-4node-1:/home/huailong# kubectl get pods -n searchqa
NAME                                            READY   STATUS    RESTARTS   AGE
embedding-svc-deployment-85fbdbbdbf-vstxf       1/1     Running   0          41m
llm-svc-deployment-9d4bd55b7-vlltd              1/1     Running   0          40m
reranking-svc-deployment-6c988dbdc5-mxvr9       1/1     Running   0          41m
router-server-67fdbd7699-jg24l                  1/1     Running   0          40m
tei-embedding-svc-deployment-c8f597f77-7kq72    1/1     Running   0          103m
tei-reranking-svc-deployment-8674bdd656-7hffr   1/1     Running   0          103m
tgi-service-m-deployment-647967c8fb-rnqps       1/1     Running   0          103m
web-retriever-svc-deployment-598586d9b4-fkdsm   1/1     Running   0          41m
root@satg-opea-4node-1:/home/huailong# 
root@satg-opea-4node-1:/home/huailong# kubectl get gmc -n searchqa
NAME       URL                                                     READY   AGE
searchqa   http://router-service.searchqa.svc.cluster.local:8080   7/0/7   100m
root@satg-opea-4node-1:/home/huailong# 
root@satg-opea-4node-1:/home/huailong# 
root@satg-opea-4node-1:/home/huailong# kubectl exec "$CLIENT_POD" -n chatqa -- curl $accessUrl  -X POST  -d '{"text":"What is the latest news? Give me also the source link."}' -H 'Content-Type: application/json'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   877  100   812  100   data: b'\n'     3  0:00:21  0:00:20  0:00:01   176

data: b'\n'

data: b'An'

data: b'swer'

data: b':'

data: b' The'

data: b' latest'

data: b' news'

data: b' can'

data: b' be'

data: b' found'

data: b' at'

data: b' the'

data: b' source'

data: b' link'

data: b':'

data: b' https'

data: b'://'

data: b'www'

data: b'.'

data: b'c'

data: b'nn'

data: b'.'

data: b'com'

data: b'/,'

data: b' where'

data: b' you'

data: b' can'

data: b' view'

data: b' breaking'

data: b' news'

data: b' today'

data: b' for'

data: b' various'

data: b' categories'

data: b' such'

data: b' as'

data: b' U'

data: b'.'

data: b'S'

data: b'.,'

data: b' world'

data: b','

data: b' weather'

data: b','

data: b' entertainment'

data: b','

data: b' politics'

data: b','

data: b' and'

data: b' health'

data: b'.'

data: b'</s>'

data: [DONE]

 65     38      3  0:00:21  0:00:20  0:00:01   224
```
