### PR TITLE
Disable runAsRoot for speecht5 and whisper

### DIFF
--- a/helm-charts/common/speecht5/templates/deployment.yaml
+++ b/helm-charts/common/speecht5/templates/deployment.yaml
@@ -38,7 +38,11 @@ spec:
                 optional: true
             {{- end }}
           securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/helm-charts/common/whisper/templates/deployment.yaml
+++ b/helm-charts/common/whisper/templates/deployment.yaml
@@ -38,7 +38,11 @@ spec:
                 optional: true
             {{- end }}
           securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
           image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/manifests/common/speecht5.yaml
+++ b/manifests/common/speecht5.yaml
@@ -84,15 +84,7 @@ spec:
                 name: extra-env-config
                 optional: true
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: false
-            runAsNonRoot: true
-            runAsUser: 1000
-            seccompProfile:
-              type: RuntimeDefault
+            {}
           image: "opea/speecht5:latest"
           imagePullPolicy: IfNotPresent
           ports:

--- a/manifests/common/speecht5_gaudi.yaml
+++ b/manifests/common/speecht5_gaudi.yaml
@@ -84,15 +84,7 @@ spec:
                 name: extra-env-config
                 optional: true
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: false
-            runAsNonRoot: true
-            runAsUser: 1000
-            seccompProfile:
-              type: RuntimeDefault
+            {}
           image: "opea/speecht5-gaudi:latest"
           imagePullPolicy: IfNotPresent
           ports:

--- a/manifests/common/whisper.yaml
+++ b/manifests/common/whisper.yaml
@@ -84,15 +84,7 @@ spec:
                 name: extra-env-config
                 optional: true
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: false
-            runAsNonRoot: true
-            runAsUser: 1000
-            seccompProfile:
-              type: RuntimeDefault
+            {}
           image: "opea/whisper:latest"
           imagePullPolicy: IfNotPresent
           ports:

--- a/manifests/common/whisper_gaudi.yaml
+++ b/manifests/common/whisper_gaudi.yaml
@@ -84,15 +84,7 @@ spec:
                 name: extra-env-config
                 optional: true
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: false
-            runAsNonRoot: true
-            runAsUser: 1000
-            seccompProfile:
-              type: RuntimeDefault
+            {}
           image: "opea/whisper-gaudi:latest"
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
## Description

The current speecht5 and whisper doesn't allow runAsRoot if the /data directory is mounted from hostPath due to the permission issue inside the docker image.


## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a.

## Tests

Describe the tests that you ran to verify your changes.
