### PR TITLE
Use upstream tei-gaudi image

### DIFF
--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -29,14 +29,13 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
-# wait for issue https://github.com/opea-project/GenAIExamples/issues/426 to be resolved
-#tei:
-#  image:
-#    repository: opea/tei-gaudi
-#    tag: "latest"
-#  resources:
-#    limits:
-#      habana.ai/gaudi: 1
+tei:
+  image:
+    repository: ghcr.io/huggingface/tei-gaudi
+    tag: synapse_1.16
+  resources:
+    limits:
+      habana.ai/gaudi: 1
 
 # To override values in subchart tgi
 tgi:

--- a/helm-charts/common/tei/gaudi-values.yaml
+++ b/helm-charts/common/tei/gaudi-values.yaml
@@ -11,10 +11,10 @@ port: 2081
 shmSize: 1Gi
 EMBEDDING_MODEL_ID: "BAAI/bge-base-en-v1.5"
 image:
-  repository: opea/tei-gaudi
+  repository: ghcr.io/huggingface/tei-gaudi
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: synapse_1.16
 
 imagePullSecrets: []
 nameOverride: ""

--- a/manifests/common/tei_gaudi.yaml
+++ b/manifests/common/tei_gaudi.yaml
@@ -87,7 +87,7 @@ spec:
                 optional: true
           securityContext:
             {}
-          image: "opea/tei-gaudi:latest"
+          image: "ghcr.io/huggingface/tei-gaudi:synapse_1.16"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data


### PR DESCRIPTION
## Description

Since upstream tei-gaudi has released its first official image, we use it instead of locally built opea/tei-gaudi.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a

## Tests

Describe the tests that you ran to verify your changes.
