### PR TITLE
doc: fix missing first heading in markdown files

### DIFF
--- a/manifests/ChatQnA/README.md
+++ b/manifests/ChatQnA/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy ChatQnA in Kubernetes Cluster on Xeon</h1>
+# Deploy ChatQnA in Kubernetes Cluster on Xeon
 
 ## Prebuilt images
 
@@ -20,7 +20,7 @@ For Gaudi:
 - tgi-service: ghcr.io/huggingface/tgi-gaudi:1.2.1
 
 > [NOTE]  
-> Please refer README [for Xeon](https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker-composer/xeon/README.md) and [for Gaudi](https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker-composer/gaudi/README.md) to build the opea images
+> Refer to the README [for Xeon](https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker-composer/xeon/README.md) and [for Gaudi](https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker-composer/gaudi/README.md) to build the opea images
 
 ## Deploy Services with Xeon
 

--- a/manifests/CodeGen/gaudi/README.md
+++ b/manifests/CodeGen/gaudi/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy CodeGen in Kubernetes Cluster on Xeon</h1>
+# Deploy CodeGen in Kubernetes Cluster on Xeon
 
 ## Deploy Services
 

--- a/manifests/CodeGen/xeon/README.md
+++ b/manifests/CodeGen/xeon/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy CodeGen in Kubernetes Cluster on Xeon</h1>
+# Deploy CodeGen in Kubernetes Cluster on Xeon
 
 ## Deploy Services
 

--- a/manifests/CodeTrans/README.md
+++ b/manifests/CodeTrans/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy CodeTrans llm-uservice in Kubernetes Cluster</h1>
+# Deploy CodeTrans llm-uservice in Kubernetes Cluster
 
 > [NOTE]
 > The following values must be set before you can deploy:

--- a/manifests/DocSum/README.md
+++ b/manifests/DocSum/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy DocSum llm-uservice in Kubernetes Cluster</h1>
+# Deploy DocSum llm-uservice in Kubernetes Cluster
 
 > [NOTE]
 > The following values must be set before you can deploy:

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Kubernetes manifests for GenAIComps</h1>
+# Kubernetes manifests for GenAIComps
 
 > [NOTE]
 > The manifests are generated from helm charts automatically.

--- a/scripts/ray/README.md
+++ b/scripts/ray/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title">Deploy Autoscaling Ray Cluster with KubeRay in Kubernetes Cluster</h1>
+# Deploy Autoscaling Ray Cluster with KubeRay in Kubernetes Cluster
 
 ## Install KubeRay
 


### PR DESCRIPTION
markdown expects a first H1 (#) heading as the title for the document.

