### PR TITLE
Add script to dump failed pod status and logs

### DIFF
--- a/.github/workflows/chart-e2e.yaml
+++ b/.github/workflows/chart-e2e.yaml
@@ -120,7 +120,6 @@ jobs:
           helm-charts/update_dependency.sh && helm dependency update ${{ env.CHART_FOLDER}}
           value_file="values.yaml"
           if [ "${{ matrix.hardware }}" == "gaudi" ]; then
-            # EXTRAPARAM="--set tgi.image.tag=1.2.1"
             if [ -f ${{ env.CHART_FOLDER}}/gaudi-values.yaml ]; then
               value_file="gaudi-values.yaml"
             else
@@ -137,6 +136,7 @@ jobs:
               $RELEASE_NAME ${{ env.CHART_FOLDER}} ; then
             echo "Failed to install chart ${{ matrix.example }}"
             echo "skip_validate=true" >> $GITHUB_ENV
+            .github/workflows/scripts/e2e/chart_test.sh dump_pods_status $NAMESPACE
             exit 1
           fi
           sleep 120
@@ -162,6 +162,7 @@ jobs:
             if [[ -f $LOG_PATH/charts-${chart}.log ]] && \
             [[ $(grep -c "^Phase:.*Failed" $LOG_PATH/charts-${chart}.log) != 0 ]]; then
                 teststatus=false
+                .github/workflows/scripts/e2e/chart_test.sh dump_failed_pod_logs $NAMESPACE $LOG_PATH/charts-${chart}.log
             else
                 teststatus=true
             fi


### PR DESCRIPTION
## Description

To improve the observability of CI jobs, add script to dump failed pod status and logs
Remove chart_test unused scripts

## Issues

closes #154 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

Show the status of not ready pods when deployment failed: https://github.com/opea-project/GenAIInfra/actions/runs/10091994310/job/27904720282#step:7:102
Show the log of failed pods when test failed: https://github.com/opea-project/GenAIInfra/actions/runs/10105854507/job/27947016154#step:8:151
