### PR TITLE
Move hf token from gmc_install script to chatQnA validation

### DIFF
--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -46,6 +46,7 @@ jobs:
           echo "should_cleanup=false" >> $GITHUB_ENV
           echo "skip_validate=false" >> $GITHUB_ENV
           echo "KIND_MOUNT_DIR=/mnt/huggingface/hub" >> $GITHUB_ENV
+          echo "KIND_TOKEN_DIR=/mnt/huggingface/token" >> $GITHUB_ENV
 
       - name: Install GMC
         run: |

--- a/.github/workflows/scripts/e2e/gmc_gaudi_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_gaudi_test.sh
@@ -9,6 +9,7 @@ source ${DIR}/utils.sh
 
 USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
+TOKEN_DIR=${KIND_TOKEN_DIR:-"/home/$USER_ID/.cache/huggingface/token"}
 CHATQNA_NAMESPACE="${APP_NAMESPACE}-chatqna"
 CODEGEN_NAMESPACE="${APP_NAMESPACE}-codegen"
 CODETRANS_NAMESPACE="${APP_NAMESPACE}-codetrans"
@@ -46,6 +47,7 @@ function cleanup_apps() {
 function validate_chatqna() {
    kubectl create ns $CHATQNA_NAMESPACE
    sed -i "s|namespace: chatqa|namespace: $CHATQNA_NAMESPACE|g"  $(pwd)/config/samples/chatQnA_gaudi.yaml
+   sed -i "s|insert-your-huggingface-token-here|$(cat $TOKEN_DIR)|g"  $(pwd)/config/samples/chatQnA_gaudi.yaml
    kubectl apply -f $(pwd)/config/samples/chatQnA_gaudi.yaml
 
    # Wait until the router service is ready

--- a/.github/workflows/scripts/e2e/gmc_install.sh
+++ b/.github/workflows/scripts/e2e/gmc_install.sh
@@ -63,7 +63,7 @@ function init_gmc() {
     find . -name '*.yaml' -type f -exec sed -i "s#image: opea/*#image: ${IMAGE_REPO}opea/#g" {} \;
     find . -name '*.yaml' -type f -exec sed -i "s#image: \"opea/*#image: \"${IMAGE_REPO}opea/#g" {} \;
     # set huggingface token
-    find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat $TOKEN_DIR)#g" {} \;
+    #find . -name '*.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#$(cat $TOKEN_DIR)#g" {} \;
     # replace the pull policy "IfNotPresent" with "Always"
     find . -name '*.yaml' -type f -exec sed -i "s#imagePullPolicy: IfNotPresent#imagePullPolicy: Always#g" {} \;
 }

--- a/.github/workflows/scripts/e2e/gmc_xeon_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_xeon_test.sh
@@ -9,6 +9,7 @@ source ${DIR}/utils.sh
 
 USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
+TOKEN_DIR=${KIND_TOKEN_DIR:-"/home/$USER_ID/.cache/huggingface/token"}
 CHATQNA_NAMESPACE="${APP_NAMESPACE}-chatqna"
 CODEGEN_NAMESPACE="${APP_NAMESPACE}-codegen"
 CODETRANS_NAMESPACE="${APP_NAMESPACE}-codetrans"
@@ -46,6 +47,7 @@ function cleanup_apps() {
 function validate_chatqna() {
    kubectl create ns $CHATQNA_NAMESPACE
    sed -i "s|namespace: chatqa|namespace: $CHATQNA_NAMESPACE|g"  $(pwd)/config/samples/chatQnA_xeon.yaml
+   sed -i "s|insert-your-huggingface-token-here|$(cat $TOKEN_DIR)|g"  $(pwd)/config/samples/chatQnA_xeon.yaml
    kubectl apply -f $(pwd)/config/samples/chatQnA_xeon.yaml
 
    # Wait until the router service is ready

--- a/microservices-connector/config/samples/chatQnA_gaudi.yaml
+++ b/microservices-connector/config/samples/chatQnA_gaudi.yaml
@@ -60,9 +60,12 @@ spec:
           config:
             endpoint: /v1/chat/completions
             TGI_LLM_ENDPOINT: tgi-gaudi-svc
+            HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
       - name: TgiGaudi
         internalService:
           serviceName: tgi-gaudi-svc
           config:
             endpoint: /generate
+            HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+            HF_TOKEN: "insert-your-huggingface-token-here"
           isDownstreamService: true

--- a/microservices-connector/config/samples/chatQnA_switch_gaudi.yaml
+++ b/microservices-connector/config/samples/chatQnA_switch_gaudi.yaml
@@ -114,6 +114,8 @@ spec:
             config:
               endpoint: /generate
               MODEL_ID: Intel/neural-chat-7b-v3-3
+              HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+              HF_TOKEN: "insert-your-huggingface-token-here"
             isDownstreamService: true
         - name: TgiGaudi
           internalService:
@@ -121,4 +123,6 @@ spec:
             config:
               endpoint: /generate
               MODEL_ID: openlm-research/open_llama_3b
+              HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+              HF_TOKEN: "insert-your-huggingface-token-here"
             isDownstreamService: true

--- a/microservices-connector/config/samples/chatQnA_switch_xeon.yaml
+++ b/microservices-connector/config/samples/chatQnA_switch_xeon.yaml
@@ -114,6 +114,8 @@ spec:
             config:
               endpoint: /generate
               MODEL_ID: Intel/neural-chat-7b-v3-3
+              HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+              HF_TOKEN: "insert-your-huggingface-token-here"
             isDownstreamService: true
         - name: Tgi
           internalService:
@@ -121,4 +123,6 @@ spec:
             config:
               endpoint: /generate
               MODEL_ID: bigscience/bloom-560m
+              HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+              HF_TOKEN: "insert-your-huggingface-token-here"
             isDownstreamService: true

--- a/microservices-connector/config/samples/chatQnA_xeon.yaml
+++ b/microservices-connector/config/samples/chatQnA_xeon.yaml
@@ -60,9 +60,12 @@ spec:
           config:
             endpoint: /v1/chat/completions
             TGI_LLM_ENDPOINT: tgi-service-m
+            HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
       - name: Tgi
         internalService:
           serviceName: tgi-service-m
           config:
             endpoint: /generate
+            HUGGING_FACE_HUB_TOKEN: "insert-your-huggingface-token-here"
+            HF_TOKEN: "insert-your-huggingface-token-here"
           isDownstreamService: true


### PR DESCRIPTION
## Description

Move hf token setting from gmc_install script to chatQnA validation script because hf token shall be set by users not by gmc installer

## Issues

closes #211 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

GenAIExamples shall be updated later

## Tests

n/a
