### PR TITLE
Enable using PV as model cache directory

### DIFF
--- a/helm-charts/common/speecht5/templates/deployment.yaml
+++ b/helm-charts/common/speecht5/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else if .Values.global.modelUsePV }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/speecht5/values.yaml
+++ b/helm-charts/common/speecht5/values.yaml
@@ -84,4 +84,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+
+  # Choose where to save your downloaded models
+  # modelUseHostPath: Host directory path, this is good for one node test.
+  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
+  # comment out both will not have model cache directory and download the model from huggingface.
   modelUseHostPath: /mnt/opea-models
+  # modelUsePV: model-volume

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else if .Values.global.modelUsePV }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -82,6 +82,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
-  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
-  # comment out modeluseHostPath if you want to download the model from huggingface
+
+  # Choose where to save your downloaded models
+  # modelUseHostPath: Host directory path, this is good for one node test.
+  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
+  # comment out both will not have model cache directory and download the model from huggingface.
   modelUseHostPath: /mnt/opea-models
+  # modelUsePV: model-volume

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else if .Values.global.modelUsePV }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -82,6 +82,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
-  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
-  # comment out modeluseHostPath if you want to download the model from huggingface
+
+  # Choose where to save your downloaded models
+  # modelUseHostPath: Host directory path, this is good for one node test.
+  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
+  # comment out both will not have model cache directory and download the model from huggingface.
   modelUseHostPath: /mnt/opea-models
+  # modelUsePV: model-volume

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else if .Values.global.modelUsePV }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -103,6 +103,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
-  # set modelUseHostPath to host directory if you want to use hostPath volume for model storage
-  # comment out modeluseHostPath if you want to download the model from huggingface
+
+  # Choose where to save your downloaded models
+  # modelUseHostPath: Host directory path, this is good for one node test.
+  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
+  # comment out both will not have model cache directory and download the model from huggingface.
   modelUseHostPath: /mnt/opea-models
+  # modelUsePV: model-volume

--- a/helm-charts/common/whisper/templates/deployment.yaml
+++ b/helm-charts/common/whisper/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
+          {{- else if .Values.global.modelUsePV }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/whisper/values.yaml
+++ b/helm-charts/common/whisper/values.yaml
@@ -83,4 +83,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+
+  # Choose where to save your downloaded models
+  # modelUseHostPath: Host directory path, this is good for one node test.
+  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
+  # comment out both will not have model cache directory and download the model from huggingface.
   modelUseHostPath: /mnt/opea-models
+  # modelUsePV: model-volume


### PR DESCRIPTION
Set modelUsePV to pvc name for model cache

## Description

modelUsePV support

## Issues

#128 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Verified using nfs as PV backend.
Setup example:
PV:
apiVersion: v1
kind: PersistentVolume
metadata:
  name: nfspv
spec:
  capacity:
    storage: 300Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  storageClassName: nfs
  nfs:
    path: "/data/nfspv"
    server: "192.168.0.184"
    readOnly: false

PV Claim:
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: model-volume
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: "nfs"
  resources:
    requests:
      storage: 1Mi

Test example with whisper:
helm install whisper whisper --set global.modelUseHostPath="" --set global.modelUsePV=model-volume --set replicaCount=4 --set image.tag=latest