### PR TITLE
Set model-volume default to tmp volume

### DIFF
--- a/helm-charts/common/speecht5/templates/deployment.yaml
+++ b/helm-charts/common/speecht5/templates/deployment.yaml
@@ -70,13 +70,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
-          {{- if .Values.global.modelUseHostPath }}
+          {{- if .Values.global.modelUsePVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePVC }}
+          {{- else if .Values.global.modelUseHostPath }}
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
-          {{- else if .Values.global.modelUsePV }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/speecht5/values.yaml
+++ b/helm-charts/common/speecht5/values.yaml
@@ -86,8 +86,11 @@ global:
   no_proxy: ""
 
   # Choose where to save your downloaded models
-  # modelUseHostPath: Host directory path, this is good for one node test.
-  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
-  # comment out both will not have model cache directory and download the model from huggingface.
-  modelUseHostPath: /mnt/opea-models
-  # modelUsePV: model-volume
+  # Set modelUseHostPath for local directory, this is good for one node test. Example:
+  # modelUseHostPath: /mnt/opea-models
+  # Set modelUsePVC for PersistentVolumeClaim(PVC), which is suitable for multinode deployment. Example:
+  # modelUsePVC: model-volume
+  # You can only set one of the following var, the behavior is not defined is both are set.
+  # By default, both var are set to empty, the model will be downloaded and saved to a tmp volume.
+  modelUseHostPath: ""
+  modelUsePVC: ""

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -74,13 +74,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
-          {{- if .Values.global.modelUseHostPath }}
+          {{- if .Values.global.modelUsePVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePVC }}
+          {{- else if .Values.global.modelUseHostPath }}
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
-          {{- else if .Values.global.modelUsePV }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -84,8 +84,11 @@ global:
   no_proxy: ""
 
   # Choose where to save your downloaded models
-  # modelUseHostPath: Host directory path, this is good for one node test.
-  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
-  # comment out both will not have model cache directory and download the model from huggingface.
-  modelUseHostPath: /mnt/opea-models
-  # modelUsePV: model-volume
+  # Set modelUseHostPath for local directory, this is good for one node test. Example:
+  # modelUseHostPath: /mnt/opea-models
+  # Set modelUsePVC for PersistentVolumeClaim(PVC), which is suitable for multinode deployment. Example:
+  # modelUsePVC: model-volume
+  # You can only set one of the following var, the behavior is not defined is both are set.
+  # By default, both var are set to empty, the model will be downloaded and saved to a tmp volume.
+  modelUseHostPath: ""
+  modelUsePVC: ""

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -74,13 +74,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
-          {{- if .Values.global.modelUseHostPath }}
+          {{- if .Values.global.modelUsePVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePVC }}
+          {{- else if .Values.global.modelUseHostPath }}
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
-          {{- else if .Values.global.modelUsePV }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -84,8 +84,11 @@ global:
   no_proxy: ""
 
   # Choose where to save your downloaded models
-  # modelUseHostPath: Host directory path, this is good for one node test.
-  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
-  # comment out both will not have model cache directory and download the model from huggingface.
-  modelUseHostPath: /mnt/opea-models
-  # modelUsePV: model-volume
+  # Set modelUseHostPath for local directory, this is good for one node test. Example:
+  # modelUseHostPath: /mnt/opea-models
+  # Set modelUsePVC for PersistentVolumeClaim(PVC), which is suitable for multinode deployment. Example:
+  # modelUsePVC: model-volume
+  # You can only set one of the following var, the behavior is not defined is both are set.
+  # By default, both var are set to empty, the model will be downloaded and saved to a tmp volume.
+  modelUseHostPath: ""
+  modelUsePVC: ""

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -70,13 +70,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
-          {{- if .Values.global.modelUseHostPath }}
+          {{- if .Values.global.modelUsePVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePVC }}
+          {{- else if .Values.global.modelUseHostPath }}
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
-          {{- else if .Values.global.modelUsePV }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -108,8 +108,11 @@ global:
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
 
   # Choose where to save your downloaded models
-  # modelUseHostPath: Host directory path, this is good for one node test.
-  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
-  # comment out both will not have model cache directory and download the model from huggingface.
-  modelUseHostPath: /mnt/opea-models
-  # modelUsePV: model-volume
+  # Set modelUseHostPath for local directory, this is good for one node test. Example:
+  # modelUseHostPath: /mnt/opea-models
+  # Set modelUsePVC for PersistentVolumeClaim(PVC), which is suitable for multinode deployment. Example:
+  # modelUsePVC: model-volume
+  # You can only set one of the following var, the behavior is not defined is both are set.
+  # By default, both var are set to empty, the model will be downloaded and saved to a tmp volume.
+  modelUseHostPath: ""
+  modelUsePVC: ""

--- a/helm-charts/common/whisper/templates/deployment.yaml
+++ b/helm-charts/common/whisper/templates/deployment.yaml
@@ -70,13 +70,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: model-volume
-          {{- if .Values.global.modelUseHostPath }}
+          {{- if .Values.global.modelUsePVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.global.modelUsePVC }}
+          {{- else if .Values.global.modelUseHostPath }}
           hostPath:
             path: {{ .Values.global.modelUseHostPath }}
             type: Directory
-          {{- else if .Values.global.modelUsePV }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.global.modelUsePV }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm-charts/common/whisper/values.yaml
+++ b/helm-charts/common/whisper/values.yaml
@@ -85,8 +85,11 @@ global:
   no_proxy: ""
 
   # Choose where to save your downloaded models
-  # modelUseHostPath: Host directory path, this is good for one node test.
-  # modelUsePV: PersistentVolumeClaim(PVC) name, which is suitable for multinode deployment
-  # comment out both will not have model cache directory and download the model from huggingface.
-  modelUseHostPath: /mnt/opea-models
-  # modelUsePV: model-volume
+  # Set modelUseHostPath for local directory, this is good for one node test. Example:
+  # modelUseHostPath: /mnt/opea-models
+  # Set modelUsePVC for PersistentVolumeClaim(PVC), which is suitable for multinode deployment. Example:
+  # modelUsePVC: model-volume
+  # You can only set one of the following var, the behavior is not defined is both are set.
+  # By default, both var are set to empty, the model will be downloaded and saved to a tmp volume.
+  modelUseHostPath: ""
+  modelUsePVC: ""

--- a/helm-charts/update_manifests.sh
+++ b/helm-charts/update_manifests.sh
@@ -5,6 +5,7 @@
 
 CUR_DIR=$(cd $(dirname "$0") && pwd)
 OUTPUTDIR=${CUR_DIR}/../microservices-connector/config/manifests
+MODELPATH="/mnt/opea-models"
 
 #
 # generate_yaml <chart> <outputdir>
@@ -18,7 +19,7 @@ function generate_yaml {
      extraparams="--set image.tag=latest"
   fi
 
-  helm template $chart ./common/$chart --skip-tests --values ./common/$chart/values.yaml --set global.extraEnvConfig=extra-env-config,noProbe=true $extraparams > ${outputdir}/$chart.yaml
+  helm template $chart ./common/$chart --skip-tests --values ./common/$chart/values.yaml --set global.extraEnvConfig=extra-env-config,global.modelUseHostPath=$MODELPATH,noProbe=true $extraparams > ${outputdir}/$chart.yaml
 
   for f in `ls ./common/$chart/*-values.yaml 2>/dev/null `; do
     ext=$(basename $f | cut -d'-' -f1)
@@ -26,7 +27,7 @@ function generate_yaml {
     if [[ $(grep -c 'tag: ""' $f) != 0 ]]; then
        extraparams="--set image.tag=latest"
     fi
-    helm template $chart ./common/$chart --skip-tests --values ${f} --set global.extraEnvConfig=extra-env-config,noProbe=true $extraparams > ${outputdir}/${chart}_${ext}.yaml
+    helm template $chart ./common/$chart --skip-tests --values ${f} --set global.extraEnvConfig=extra-env-config,global.modelUseHostPath=$MODELPATH,noProbe=true $extraparams > ${outputdir}/${chart}_${ext}.yaml
   done
 }
 
@@ -42,4 +43,4 @@ done
 
 # we need special version of docsum-llm-uservice
 echo "Update manifest for docsum-llm-uservice..."
-helm template docsum ./common/llm-uservice --skip-tests --set global.extraEnvConfig=extra-env-config,noProbe=true,image.repository=opea/llm-docsum-tgi,image.tag=latest> ${OUTPUTDIR}/docsum-llm-uservice.yaml
+helm template docsum ./common/llm-uservice --skip-tests --set global.extraEnvConfig=extra-env-config,global.modelUseHostPath=$MODELPATH,noProbe=true,image.repository=opea/llm-docsum-tgi,image.tag=latest> ${OUTPUTDIR}/docsum-llm-uservice.yaml


### PR DESCRIPTION
Set default value for model-volume to tmp volume.
Change modelUsePV to modelUsePVC as this is PVC.
Make modelUsePVC high priority than modelUseHostPath.

## Description

Minor fixes to PVC setting

## Issues

#128 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
Try with different settings and check the volume:
helm install tgi tgi --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN}

helm install tgi tgi --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUsePVC=model-volume

helm install tgi tgi --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=/mnt/models

helm install tgiboth tgi --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=/mnt/models --set global.modelUsePVC=model-volume