### PR TITLE
Support HF_ENDPOINT

### DIFF
--- a/helm-charts/common/data-prep/templates/configmap.yaml
+++ b/helm-charts/common/data-prep/templates/configmap.yaml
@@ -22,6 +22,9 @@ data:
   INDEX_NAME: {{ .Values.INDEX_NAME | quote }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}
   {{- if and (not .Values.REDIS_URL) (and (not .Values.TEI_EMBEDDING_ENDPOINT) (or .Values.global.http_proxy .Values.global.https_proxy)) }}

--- a/helm-charts/common/llm-uservice/templates/configmap.yaml
+++ b/helm-charts/common/llm-uservice/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
   {{- end }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}
   {{- if and (not .Values.TGI_LLM_ENDPOINT) (or .Values.global.http_proxy .Values.global.https_proxy) }}

--- a/helm-charts/common/speecht5/templates/configmap.yaml
+++ b/helm-charts/common/speecht5/templates/configmap.yaml
@@ -14,4 +14,7 @@ data:
   https_proxy: {{ .Values.global.https_proxy | quote }}
   no_proxy: {{ .Values.global.no_proxy | quote }}
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   HUGGINGFACE_HUB_CACHE: "/data"

--- a/helm-charts/common/tei/templates/configmap.yaml
+++ b/helm-charts/common/tei/templates/configmap.yaml
@@ -16,4 +16,7 @@ data:
   NUMBA_CACHE_DIR: "/tmp"
   TRANSFORMERS_CACHE: "/tmp/transformers_cache"
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   MAX_WARMUP_SEQUENCE_LENGTH: "512"

--- a/helm-charts/common/teirerank/templates/configmap.yaml
+++ b/helm-charts/common/teirerank/templates/configmap.yaml
@@ -16,3 +16,6 @@ data:
   NUMBA_CACHE_DIR: "/tmp"
   TRANSFORMERS_CACHE: "/tmp/transformers_cache"
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}

--- a/helm-charts/common/tgi/templates/configmap.yaml
+++ b/helm-charts/common/tgi/templates/configmap.yaml
@@ -11,6 +11,9 @@ data:
   MODEL_ID: {{ .Values.LLM_MODEL_ID | quote }}
   PORT: {{ .Values.port | quote }}
   HF_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}
   no_proxy: {{ .Values.global.no_proxy | quote }}

--- a/helm-charts/common/whisper/templates/configmap.yaml
+++ b/helm-charts/common/whisper/templates/configmap.yaml
@@ -14,4 +14,7 @@ data:
   https_proxy: {{ .Values.global.https_proxy | quote }}
   no_proxy: {{ .Values.global.no_proxy | quote }}
   HF_HOME: "/tmp/.cache/huggingface"
+  {{- if .Values.global.HF_ENDPOINT }}
+  HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
+  {{- end }}
   HUGGINGFACE_HUB_CACHE: "/data"


### PR DESCRIPTION
Support HF_ENDPOINT for use with huggingface mirrors

## Description

Please refer to this link for HF_ENDPOINT usage.
https://huggingface.co/docs/huggingface_hub/v0.13.2/en/package_reference/environment_variables#hfendpoint

## Issues

Closed #299 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Tests

helm install whispernew common/whisper --set global.HF_ENDPOINT=https://hf-mirror.com