### PR TITLE
Initial commit for Intel Gaudi Base Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ NOTE: Please make sure you configure the appropriate container runtime based on 
 
 4. [Install Intel Gaudi device plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html).
 
+Alternatively, Intel provides a base operator to manage the Gaudi software stack. Please refer to [this file](kubernetes-addons/Intel-Gaudi-Base-Operator/README.md) for details.
+
 ## Usages
 
 ### Use GenAI Microservices Connector (GMC) to deploy and adjust GenAIExamples

--- a/kubernetes-addons/Intel-Gaudi-Base-Operator/README.md
+++ b/kubernetes-addons/Intel-Gaudi-Base-Operator/README.md
@@ -1,0 +1,9 @@
+# Intel® Gaudi® Base Operator for Kubernetes
+
+Instead of installing Intel Gaudi software stack (drivers, container runtime, device plugin and etc.) manually, Intel Habana provides the [Intel® Gaudi® Base Operator for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Intel_Gaudi_Base_Operator_for_Kubernetes.html) to ease the task.
+
+Intel® Gaudi® Base Operator for Kubernetes automates the management of all necessary Intel Gaudi software components on a Kubernetes cluster. These include drivers, Kubernetes device plugin, container runtime, feature discovery, and monitoring tools.
+
+[Here](https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html#support-matrix) is the support matrix for Kubernetes versions.
+
+For more detailded information and steps to proceed, please refer to the [Intel® Gaudi® Base Operator for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Intel_Gaudi_Base_Operator_for_Kubernetes.html) manual page.


### PR DESCRIPTION
Intel provides a base operator for the provisioning of Gaudi software. This README documents the whereabouts of this base operator.

## Description

This is the initial commit to introduce Intel Gaudi Base Operator to GenAIInfra.
For now, it is fine to follow the steps in the operator manual page. Should any further issues discovered, they should be addressed in this directory.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

N/A

## Tests

N/A