### PR TITLE
tgi: revert xeon version to 2.2.0

### DIFF
--- a/.github/workflows/scripts/e2e/gmc_xeon_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_xeon_test.sh
@@ -167,7 +167,7 @@ function validate_chatqna() {
    kubectl create ns $CHATQNA_NAMESPACE
    sed -i "s|namespace: chatqa|namespace: $CHATQNA_NAMESPACE|g"  $(pwd)/config/samples/chatQnA_xeon.yaml
    # workaround for issue #268
-   yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_xeon.yaml
+   #yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_xeon.yaml
    kubectl apply -f $(pwd)/config/samples/chatQnA_xeon.yaml
 
    # Wait until the router service is ready
@@ -238,7 +238,7 @@ function validate_chatqna_with_dataprep() {
    kubectl create ns $CHATQNA_DATAPREP_NAMESPACE
    sed -i "s|namespace: chatqa|namespace: $CHATQNA_DATAPREP_NAMESPACE|g"  $(pwd)/config/samples/chatQnA_dataprep_xeon.yaml
    # workaround for issue #268
-   yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_dataprep_xeon.yaml
+   #yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_dataprep_xeon.yaml
    kubectl apply -f $(pwd)/config/samples/chatQnA_dataprep_xeon.yaml
 
    # Wait until the router service is ready
@@ -331,7 +331,7 @@ function validate_chatqna_in_switch() {
    kubectl create ns $CHATQNA_SWITCH_NAMESPACE
    sed -i "s|namespace: switch|namespace: $CHATQNA_SWITCH_NAMESPACE|g"  $(pwd)/config/samples/chatQnA_switch_xeon.yaml
    # workaround for issue #268
-   yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_switch_xeon.yaml
+   #yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/chatQnA_switch_xeon.yaml
    kubectl apply -f $(pwd)/config/samples/chatQnA_switch_xeon.yaml
 
    # Wait until the router service is ready
@@ -452,7 +452,7 @@ function validate_modify_config() {
     fi
 
     #change the model id of the step named "Tgi" in the codegen_xeon_mod.yaml
-    yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "bigscience/bloom-560m"' $(pwd)/config/samples/codegen_xeon_mod.yaml
+    yq -i '(.spec.nodes.root.steps[] | select ( .name == "Tgi")).internalService.config.MODEL_ID = "HuggingFaceH4/mistral-7b-grok"' $(pwd)/config/samples/codegen_xeon_mod.yaml
     kubectl apply -f $(pwd)/config/samples/codegen_xeon_mod.yaml
 
     pods_count=$(kubectl get pods -n $MODIFY_STEP_NAMESPACE -o jsonpath='{.items[*].metadata.name}' | wc -w)

--- a/helm-charts/common/retriever-usvc/templates/configmap.yaml
+++ b/helm-charts/common/retriever-usvc/templates/configmap.yaml
@@ -32,3 +32,4 @@ data:
   LANGCHAIN_API_KEY: {{ .Values.global.LANGCHAIN_API_KEY | quote }}
   LANGCHAIN_PROJECT: "opea-retriever-service"
   HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -92,3 +92,4 @@ global:
   no_proxy: ""
   LANGCHAIN_TRACING_V2: false
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: ghcr.io/huggingface/text-generation-inference
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest-intel-cpu"
+  tag: "2.2.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/microservices-connector/config/manifests/retriever-usvc.yaml
+++ b/microservices-connector/config/manifests/retriever-usvc.yaml
@@ -26,6 +26,7 @@ data:
   LANGCHAIN_API_KEY: "insert-your-langchain-key-here"
   LANGCHAIN_PROJECT: "opea-retriever-service"
   HF_HOME: "/tmp/.cache/huggingface"
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
 ---
 # Source: retriever-usvc/templates/service.yaml
 # Copyright (C) 2024 Intel Corporation

--- a/microservices-connector/config/manifests/tgi.yaml
+++ b/microservices-connector/config/manifests/tgi.yaml
@@ -89,7 +89,7 @@ spec:
                 optional: true
           securityContext:
             {}
-          image: "ghcr.io/huggingface/text-generation-inference:latest-intel-cpu"
+          image: "ghcr.io/huggingface/text-generation-inference:2.2.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data

--- a/microservices-connector/config/samples/chatQnA_switch_xeon.yaml
+++ b/microservices-connector/config/samples/chatQnA_switch_xeon.yaml
@@ -120,5 +120,5 @@ spec:
             serviceName: tgi-service-llama
             config:
               endpoint: /generate
-              MODEL_ID: bigscience/bloom-560m
+              MODEL_ID: HuggingFaceH4/mistral-7b-grok
             isDownstreamService: true


### PR DESCRIPTION
## Description

Due to bug opea-project/GenAIExamples#636, revert tgi xeon version to 2.2.0.

## Issues

opea-project/GenAIExamples#636

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a.

## Tests

Describe the tests that you ran to verify your changes.
