### PR TITLE
mainfest: introduce release namespace object to endpoint

### DIFF
--- a/helm-charts/common/data-prep/templates/configmap.yaml
+++ b/helm-charts/common/data-prep/templates/configmap.yaml
@@ -11,13 +11,13 @@ data:
   {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
   TEI_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
   {{- else if not .Values.EMBED_MODEL }}
-  TEI_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  TEI_ENDPOINT: "http://{{ .Release.Name }}-tei.{{ .Release.Namespace }}"
   {{- end }}
   EMBED_MODEL: {{ .Values.EMBED_MODEL | quote }}
   {{- if .Values.REDIS_URL }}
   REDIS_URL: {{ .Values.REDIS_URL | quote}}
   {{- else }}
-  REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db:6379"
+  REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db.{{ .Release.Namespace }}:6379"
   {{- end }}
   INDEX_NAME: {{ .Values.INDEX_NAME | quote }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}

--- a/helm-charts/common/embedding-usvc/templates/configmap.yaml
+++ b/helm-charts/common/embedding-usvc/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
   TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote }}
   {{- else }}
-  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei.{{ .Release.Namespace }}"
   {{- end }}
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}

--- a/helm-charts/common/llm-uservice/templates/configmap.yaml
+++ b/helm-charts/common/llm-uservice/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- if .Values.TGI_LLM_ENDPOINT }}
   TGI_LLM_ENDPOINT: {{ .Values.TGI_LLM_ENDPOINT | quote}}
   {{- else }}
-  TGI_LLM_ENDPOINT: "http://{{ .Release.Name }}-tgi"
+  TGI_LLM_ENDPOINT: "http://{{ .Release.Name }}-tgi.{{ .Release.Namespace }}"
   {{- end }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
   HF_HOME: "/tmp/.cache/huggingface"

--- a/helm-charts/common/reranking-usvc/templates/configmap.yaml
+++ b/helm-charts/common/reranking-usvc/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- if .Values.TEI_RERANKING_ENDPOINT }}
   TEI_RERANKING_ENDPOINT: {{ .Values.TEI_RERANKING_ENDPOINT | quote }}
   {{- else }}
-  TEI_RERANKING_ENDPOINT: "http://{{ .Release.Name }}-teirerank"
+  TEI_RERANKING_ENDPOINT: "http://{{ .Release.Name }}-teirerank.{{ .Release.Namespace }}"
   {{- end }}
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}

--- a/helm-charts/common/retriever-usvc/templates/configmap.yaml
+++ b/helm-charts/common/retriever-usvc/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
   TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote }}
   {{- else if not .Values.EMBED_MODEL }}
-  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
+  TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei.{{ .Release.Namespace }}"
   {{- end }}
   EMBED_MODEL: {{ .Values.EMBED_MODEL | quote }}
   {{- if .Values.REDIS_URL }}


### PR DESCRIPTION
## Description

Introduce the **release namespace object** to the **endpoint**, as the current one only supports **default** namespace.

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

`n/a`

## Tests

Tested the ChatQNA with a different namespace, able to work perfectly.
![image](https://github.com/user-attachments/assets/601bb847-d5c3-4463-8bd7-b65b9581325a)
