### PR TITLE
helm: use latest image tag on main branch

### DIFF
--- a/.github/workflows/_helm-e2e.yaml
+++ b/.github/workflows/_helm-e2e.yaml
@@ -79,7 +79,7 @@ jobs:
           # insert a prefix before opea/.*, the prefix is OPEA_IMAGE_REPO
           find . -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repository: ${OPEA_IMAGE_REPO}opea/#g" {} \;
           # set OPEA image tag to ${{ inputs.tag }}
-          find . -name '*values.yaml' -type f -exec sed -i 's#tag: ""#tag: ${{ inputs.tag }}#g' {} \;
+          find . -name '*values.yaml' -type f -exec sed -i 's#tag: "latest"#tag: ${{ inputs.tag }}#g' {} \;
           # set huggingface token
           find . -name '*values.yaml' -type f -exec sed -i "s#insert-your-huggingface-token-here#${HFTOKEN}#g" {} \;
           # replace the mount dir "Volume: *" with "Volume: $CHART_MOUNT"

--- a/.github/workflows/manual-freeze-tag.yaml
+++ b/.github/workflows/manual-freeze-tag.yaml
@@ -6,24 +6,19 @@ name: Freeze helm release tag in helm charts on manual event
 on:
   workflow_dispatch:
     inputs:
-      oldappversion:
-        default: "v0.8"
-        description: "Old appVersion to be replaced"
-        required: true
-        type: string
-      newappversion:
-        default: "v0.9"
-        description: "New appVersion to replace"
-        required: true
-        type: string
       oldversion:
-        default: "0.8.0"
-        description: "Old version to be replaced"
+        default: "0.9.0"
+        description: "Old helm version to be replaced"
         required: true
         type: string
       newversion:
-        default: "0.9.0"
-        description: "New version to replace"
+        default: "1.0.0"
+        description: "New helm version to replace"
+        required: true
+        type: string
+      imageversion:
+        default: "v1.0"
+        description: "New image version to replace"
         required: true
         type: string
 
@@ -46,11 +41,11 @@ jobs:
 
       - name: Run script
         env:
-          NEWTAG: ${{ inputs.newappversion }}
+          NEWTAG: ${{ inputs.imageversion }}
         run: |
-          find helm-charts/ -name 'Chart.yaml' -type f -exec sed -i "s#appVersion: \"${{ inputs.oldappversion }}\"#appVersion: \"${{ inputs.newappversion }}\"#g" {} \;
+          find helm-charts/ -name '*values.yaml' -type f -exec sed -i "s#tag: \"latest\"#tag: \"${imageversion}\"#g" {} \;
           find helm-charts/ -name 'Chart.yaml' -type f -exec sed -i "s#version: ${{ inputs.oldversion }}#version: ${{ inputs.newversion }}#g" {} \;
-          find microservices-connector/helm/ -name 'Chart.yaml' -type f -exec sed -i "s#appVersion: \"${{ inputs.oldappversion }}\"#appVersion: \"${{ inputs.newappversion }}\"#g" {} \;
+          find microservices-connector/helm/ -name '*values.yaml' -type f -exec sed -i "s#tag: \"latest\"#tag: \"${imageversion}\"#g" {} \;
           find microservices-connector/helm/ -name 'Chart.yaml' -type f -exec sed -i "s#version: ${{ inputs.oldversion }}#version: ${{ inputs.newversion }}#g" {} \;
           sed -i "s|opea/gmcrouter:latest|opea/gmcrouter:$NEWTAG|g" microservices-connector/config/gmcrouter/gmc-router.yaml
           sed -i "s|opea/gmcmanager:latest|opea/gmcmanager:$NEWTAG|g" microservices-connector/config/manager/gmc-manager.yaml

--- a/.github/workflows/scripts/e2e/gmc_xeon_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_xeon_test.sh
@@ -21,6 +21,7 @@ MODIFY_STEP_NAMESPACE="${APP_NAMESPACE}-modstep"
 WEBHOOK_NAMESPACE="${APP_NAMESPACE}-webhook"
 
 function validate_gmc() {
+    mkdir -p ${LOG_PATH}
     echo "validate audio-qna"
     validate_audioqa
 

--- a/helm-charts/chatqna/Chart.yaml
+++ b/helm-charts/chatqna/Chart.yaml
@@ -7,31 +7,31 @@ description: The Helm chart to deploy ChatQnA
 type: application
 dependencies:
   - name: tgi
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/llm-uservice"
   - name: tei
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/tei"
   - name: embedding-usvc
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/embedding-usvc"
   - name: teirerank
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/teirerank"
   - name: reranking-usvc
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/reranking-usvc"
   - name: redis-vector-db
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/redis-vector-db"
   - name: retriever-usvc
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/retriever-usvc"
   - name: data-prep
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/data-prep"
-version: 0.9.0
-appVersion: "v0.9"
+version: 1.0.0
+appVersion: "v1.0"

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: opea/chatqna
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 port: 8888
 service:

--- a/helm-charts/codegen/Chart.yaml
+++ b/helm-charts/codegen/Chart.yaml
@@ -7,10 +7,10 @@ description: The Helm chart to deploy CodeGen
 type: application
 dependencies:
   - name: tgi
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/llm-uservice"
-version: 0.9.0
-appVersion: "v0.9"
+version: 1.0.0
+appVersion: "v1.0"

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: opea/codegen
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 port: 7778
 service:

--- a/helm-charts/codetrans/Chart.yaml
+++ b/helm-charts/codetrans/Chart.yaml
@@ -7,10 +7,10 @@ description: The Helm chart to deploy CodeTrans
 type: application
 dependencies:
   - name: tgi
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/llm-uservice"
-version: 0.9.0
-appVersion: "v0.9"
+version: 1.0.0
+appVersion: "v1.0"

--- a/helm-charts/codetrans/values.yaml
+++ b/helm-charts/codetrans/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: opea/codetrans
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 port: 7777
 service:

--- a/helm-charts/common/asr/Chart.yaml
+++ b/helm-charts/common/asr/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: asr
 description: The Helm chart for deploying asr as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The asr microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: whisper
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../whisper
     condition: autodependency.enabled

--- a/helm-charts/common/asr/values.yaml
+++ b/helm-charts/common/asr/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: opea/asr
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/chatqna-ui/Chart.yaml
+++ b/helm-charts/common/chatqna-ui/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: chatqna-ui
 description: A Helm chart to the UI for chatQnA workload
 type: application
-version: 0.9.0
-appVersion: "v0.9"
+version: 1.0.0
+appVersion: "v1.0"

--- a/helm-charts/common/chatqna-ui/values.yaml
+++ b/helm-charts/common/chatqna-ui/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: opea/chatqna-conversation-ui
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/data-prep/Chart.yaml
+++ b/helm-charts/common/data-prep/Chart.yaml
@@ -5,15 +5,15 @@ apiVersion: v2
 name: data-prep
 description: The Helm chart for deploying data prep as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The data prep microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../tei
     condition: autodependency.enabled
   - name: redis-vector-db
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../redis-vector-db
     condition: autodependency.enabled

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -14,7 +14,7 @@ image:
   repository: opea/dataprep-redis
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/embedding-usvc/Chart.yaml
+++ b/helm-charts/common/embedding-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: embedding-usvc
 description: The Helm chart for deploying embedding as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The embedding microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../tei
     condition: autodependency.enabled

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: opea/embedding-tei
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/llm-uservice/Chart.yaml
+++ b/helm-charts/common/llm-uservice/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: llm-uservice
 description: The Helm chart for deploying llm as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The llm microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: tgi
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../tgi
     condition: autodependency.enabled

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: opea/llm-tgi
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/redis-vector-db/Chart.yaml
+++ b/helm-charts/common/redis-vector-db/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: redis-vector-db
 description: The Helm chart for Redis Vector DB
 type: application
-version: 0.9.0
+version: 1.0.0
 appVersion: "7.2.0-v9"

--- a/helm-charts/common/reranking-usvc/Chart.yaml
+++ b/helm-charts/common/reranking-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: reranking-usvc
 description: The Helm chart for deploying reranking as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The reranking microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: teirerank
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../teirerank
     condition: autodependency.enabled

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: opea/reranking-tei
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/retriever-usvc/Chart.yaml
+++ b/helm-charts/common/retriever-usvc/Chart.yaml
@@ -5,15 +5,15 @@ apiVersion: v2
 name: retriever-usvc
 description: The Helm chart for deploying retriever as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The retriever microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../tei
     condition: autodependency.enabled
   - name: redis-vector-db
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../redis-vector-db
     condition: autodependency.enabled

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -20,7 +20,7 @@ image:
   repository: opea/retriever-redis
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/speecht5/Chart.yaml
+++ b/helm-charts/common/speecht5/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: speecht5
 description: The Helm chart for deploying speecht5 as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The speecht5 microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"

--- a/helm-charts/common/speecht5/gaudi-values.yaml
+++ b/helm-charts/common/speecht5/gaudi-values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: opea/speecht5-gaudi
-  tag: ""
+  tag: "latest"
 
 resources:
   limits:

--- a/helm-charts/common/speecht5/values.yaml
+++ b/helm-charts/common/speecht5/values.yaml
@@ -14,7 +14,7 @@ image:
   repository: opea/speecht5
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/tei/Chart.yaml
+++ b/helm-charts/common/tei/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tei
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 0.9.0
+version: 1.0.0
 # The HF TEI version
 appVersion: "cpu-1.5"

--- a/helm-charts/common/teirerank/Chart.yaml
+++ b/helm-charts/common/teirerank/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: teirerank
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 0.9.0
+version: 1.0.0
 # The HF TEI version
 appVersion: "cpu-1.5"

--- a/helm-charts/common/tgi/Chart.yaml
+++ b/helm-charts/common/tgi/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tgi
 description: The Helm chart for HuggingFace Text Generation Inference Server
 type: application
-version: 0.9.0
+version: 1.0.0
 # The HF TGI version
 appVersion: "2.1.0"

--- a/helm-charts/common/tts/Chart.yaml
+++ b/helm-charts/common/tts/Chart.yaml
@@ -5,12 +5,12 @@ apiVersion: v2
 name: tts
 description: The Helm chart for deploying tts as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The tts microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 
 dependencies:
   - name: speecht5
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../speecht5
     condition: autodependency.enabled

--- a/helm-charts/common/tts/values.yaml
+++ b/helm-charts/common/tts/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: opea/tts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/web-retriever/Chart.yaml
+++ b/helm-charts/common/web-retriever/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: web-retriever
 description: The Helm chart for deploying web retriever as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The web retriever microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 0.9.0
+    version: 1.0.0
     repository: file://../tei
     condition: autodependency.enabled

--- a/helm-charts/common/web-retriever/values.yaml
+++ b/helm-charts/common/web-retriever/values.yaml
@@ -18,7 +18,7 @@ image:
   repository: opea/web-retriever-chroma
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/common/whisper/Chart.yaml
+++ b/helm-charts/common/whisper/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: whisper
 description: The Helm chart for deploying whisper as microservice
 type: application
-version: 0.9.0
+version: 1.0.0
 # The whisper microservice server version
-appVersion: "v0.9"
+appVersion: "v1.0"

--- a/helm-charts/common/whisper/gaudi-values.yaml
+++ b/helm-charts/common/whisper/gaudi-values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: opea/whisper-gaudi
-  tag: ""
+  tag: "latest"
 
 resources:
   limits:

--- a/helm-charts/common/whisper/values.yaml
+++ b/helm-charts/common/whisper/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: opea/whisper
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-charts/docsum/Chart.yaml
+++ b/helm-charts/docsum/Chart.yaml
@@ -7,10 +7,10 @@ description: The Helm chart to deploy DocSum
 type: application
 dependencies:
   - name: tgi
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 0.9.0
+    version: 1.0.0
     repository: "file://../common/llm-uservice"
-version: 0.9.0
-appVersion: "v0.9"
+version: 1.0.0
+appVersion: "v1.0"

--- a/helm-charts/docsum/values.yaml
+++ b/helm-charts/docsum/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: opea/docsum
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 port: 8888
 service:

--- a/helm-charts/update_manifests.sh
+++ b/helm-charts/update_manifests.sh
@@ -16,7 +16,7 @@ function generate_yaml {
   outputdir=$2
 
   local extraparams=""
-  if [[ $(grep -c 'tag: ""' ./common/$chart/values.yaml) != 0 ]]; then
+  if [[ $(grep -c 'tag: "latest"' ./common/$chart/values.yaml) != 0 ]]; then
      extraparams="--set image.tag=$NEWTAG"
   fi
 
@@ -25,7 +25,7 @@ function generate_yaml {
   for f in `ls ./common/$chart/*-values.yaml 2>/dev/null `; do
     ext=$(basename $f | cut -d'-' -f1)
     extraparams=""
-    if [[ $(grep -c 'tag: ""' $f) != 0 ]]; then
+    if [[ $(grep -c 'tag: "latest"' $f) != 0 ]]; then
        extraparams="--set image.tag=$NEWTAG"
     fi
     helm template $chart ./common/$chart --skip-tests --values ${f} --set global.extraEnvConfig=extra-env-config,global.modelUseHostPath=$MODELPATH,noProbe=true $extraparams > ${outputdir}/${chart}_${ext}.yaml

--- a/microservices-connector/config/manifests/asr.yaml
+++ b/microservices-connector/config/manifests/asr.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: asr-config
   labels:
-    helm.sh/chart: asr-0.9.0
+    helm.sh/chart: asr-1.0.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   ASR_ENDPOINT: "http://asr-whisper:7066"
@@ -28,10 +28,10 @@ kind: Service
 metadata:
   name: asr
   labels:
-    helm.sh/chart: asr-0.9.0
+    helm.sh/chart: asr-1.0.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -53,10 +53,10 @@ kind: Deployment
 metadata:
   name: asr
   labels:
-    helm.sh/chart: asr-0.9.0
+    helm.sh/chart: asr-1.0.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/chatqna-ui.yaml
+++ b/microservices-connector/config/manifests/chatqna-ui.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: chatqna-ui-config
   labels:
-    helm.sh/chart: chatqna-ui-0.9.0
+    helm.sh/chart: chatqna-ui-1.0.0
     app.kubernetes.io/name: chatqna-ui
     app.kubernetes.io/instance: chatqna-ui
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   http_proxy: ""
@@ -33,10 +33,10 @@ kind: Service
 metadata:
   name: chatqna-ui
   labels:
-    helm.sh/chart: chatqna-ui-0.9.0
+    helm.sh/chart: chatqna-ui-1.0.0
     app.kubernetes.io/name: chatqna-ui
     app.kubernetes.io/instance: chatqna-ui
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -58,10 +58,10 @@ kind: Deployment
 metadata:
   name: chatqna-ui
   labels:
-    helm.sh/chart: chatqna-ui-0.9.0
+    helm.sh/chart: chatqna-ui-1.0.0
     app.kubernetes.io/name: chatqna-ui
     app.kubernetes.io/instance: chatqna-ui
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -72,10 +72,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-0.9.0
+        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna-ui
-        app.kubernetes.io/version: "v0.9"
+        app.kubernetes.io/version: "v1.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:

--- a/microservices-connector/config/manifests/data-prep.yaml
+++ b/microservices-connector/config/manifests/data-prep.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: data-prep-config
   labels:
-    helm.sh/chart: data-prep-0.9.0
+    helm.sh/chart: data-prep-1.0.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TEI_ENDPOINT: "http://data-prep-tei"
@@ -36,10 +36,10 @@ kind: Service
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-0.9.0
+    helm.sh/chart: data-prep-1.0.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -61,10 +61,10 @@ kind: Deployment
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-0.9.0
+    helm.sh/chart: data-prep-1.0.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/docsum-llm-uservice.yaml
+++ b/microservices-connector/config/manifests/docsum-llm-uservice.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: docsum-llm-uservice-config
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TGI_LLM_ENDPOINT: "http://docsum-tgi"
@@ -33,10 +33,10 @@ kind: Service
 metadata:
   name: docsum-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -58,10 +58,10 @@ kind: Deployment
 metadata:
   name: docsum-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/embedding-usvc.yaml
+++ b/microservices-connector/config/manifests/embedding-usvc.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: embedding-usvc-config
   labels:
-    helm.sh/chart: embedding-usvc-0.9.0
+    helm.sh/chart: embedding-usvc-1.0.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TEI_EMBEDDING_ENDPOINT: "http://embedding-usvc-tei"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: embedding-usvc
   labels:
-    helm.sh/chart: embedding-usvc-0.9.0
+    helm.sh/chart: embedding-usvc-1.0.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: embedding-usvc
   labels:
-    helm.sh/chart: embedding-usvc-0.9.0
+    helm.sh/chart: embedding-usvc-1.0.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/llm-uservice.yaml
+++ b/microservices-connector/config/manifests/llm-uservice.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: llm-uservice-config
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TGI_LLM_ENDPOINT: "http://llm-uservice-tgi"
@@ -33,10 +33,10 @@ kind: Service
 metadata:
   name: llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -58,10 +58,10 @@ kind: Deployment
 metadata:
   name: llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-0.9.0
+    helm.sh/chart: llm-uservice-1.0.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/redis-vector-db.yaml
+++ b/microservices-connector/config/manifests/redis-vector-db.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: redis-vector-db
   labels:
-    helm.sh/chart: redis-vector-db-0.9.0
+    helm.sh/chart: redis-vector-db-1.0.0
     app.kubernetes.io/name: redis-vector-db
     app.kubernetes.io/instance: redis-vector-db
     app.kubernetes.io/version: "7.2.0-v9"
@@ -37,7 +37,7 @@ kind: Deployment
 metadata:
   name: redis-vector-db
   labels:
-    helm.sh/chart: redis-vector-db-0.9.0
+    helm.sh/chart: redis-vector-db-1.0.0
     app.kubernetes.io/name: redis-vector-db
     app.kubernetes.io/instance: redis-vector-db
     app.kubernetes.io/version: "7.2.0-v9"

--- a/microservices-connector/config/manifests/reranking-usvc.yaml
+++ b/microservices-connector/config/manifests/reranking-usvc.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: reranking-usvc-config
   labels:
-    helm.sh/chart: reranking-usvc-0.9.0
+    helm.sh/chart: reranking-usvc-1.0.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TEI_RERANKING_ENDPOINT: "http://reranking-usvc-teirerank"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: reranking-usvc
   labels:
-    helm.sh/chart: reranking-usvc-0.9.0
+    helm.sh/chart: reranking-usvc-1.0.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: reranking-usvc
   labels:
-    helm.sh/chart: reranking-usvc-0.9.0
+    helm.sh/chart: reranking-usvc-1.0.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/retriever-usvc.yaml
+++ b/microservices-connector/config/manifests/retriever-usvc.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: retriever-usvc-config
   labels:
-    helm.sh/chart: retriever-usvc-0.9.0
+    helm.sh/chart: retriever-usvc-1.0.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TEI_EMBEDDING_ENDPOINT: "http://retriever-usvc-tei"
@@ -37,10 +37,10 @@ kind: Service
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-0.9.0
+    helm.sh/chart: retriever-usvc-1.0.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -62,10 +62,10 @@ kind: Deployment
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-0.9.0
+    helm.sh/chart: retriever-usvc-1.0.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/speecht5.yaml
+++ b/microservices-connector/config/manifests/speecht5.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: speecht5-config
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/speecht5_gaudi.yaml
+++ b/microservices-connector/config/manifests/speecht5_gaudi.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: speecht5-config
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-0.9.0
+    helm.sh/chart: speecht5-1.0.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/tei.yaml
+++ b/microservices-connector/config/manifests/tei.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tei-config
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -33,7 +33,7 @@ kind: Service
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/tei_gaudi.yaml
+++ b/microservices-connector/config/manifests/tei_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tei-config
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -33,7 +33,7 @@ kind: Service
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-0.9.0
+    helm.sh/chart: tei-1.0.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/teirerank.yaml
+++ b/microservices-connector/config/manifests/teirerank.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: teirerank-config
   labels:
-    helm.sh/chart: teirerank-0.9.0
+    helm.sh/chart: teirerank-1.0.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-0.9.0
+    helm.sh/chart: teirerank-1.0.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-0.9.0
+    helm.sh/chart: teirerank-1.0.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/tgi.yaml
+++ b/microservices-connector/config/manifests/tgi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tgi_gaudi.yaml
+++ b/microservices-connector/config/manifests/tgi_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -36,7 +36,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tgi_nv.yaml
+++ b/microservices-connector/config/manifests/tgi_nv.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -34,7 +34,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-0.9.0
+    helm.sh/chart: tgi-1.0.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tts.yaml
+++ b/microservices-connector/config/manifests/tts.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: tts-config
   labels:
-    helm.sh/chart: tts-0.9.0
+    helm.sh/chart: tts-1.0.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TTS_ENDPOINT: "http://tts-speecht5:7055"
@@ -28,10 +28,10 @@ kind: Service
 metadata:
   name: tts
   labels:
-    helm.sh/chart: tts-0.9.0
+    helm.sh/chart: tts-1.0.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -53,10 +53,10 @@ kind: Deployment
 metadata:
   name: tts
   labels:
-    helm.sh/chart: tts-0.9.0
+    helm.sh/chart: tts-1.0.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/web-retriever.yaml
+++ b/microservices-connector/config/manifests/web-retriever.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: web-retriever-config
   labels:
-    helm.sh/chart: web-retriever-0.9.0
+    helm.sh/chart: web-retriever-1.0.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   TEI_EMBEDDING_ENDPOINT: "http://web-retriever-tei"
@@ -32,10 +32,10 @@ kind: Service
 metadata:
   name: web-retriever
   labels:
-    helm.sh/chart: web-retriever-0.9.0
+    helm.sh/chart: web-retriever-1.0.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -57,10 +57,10 @@ kind: Deployment
 metadata:
   name: web-retriever
   labels:
-    helm.sh/chart: web-retriever-0.9.0
+    helm.sh/chart: web-retriever-1.0.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/whisper.yaml
+++ b/microservices-connector/config/manifests/whisper.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: whisper-config
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/config/manifests/whisper_gaudi.yaml
+++ b/microservices-connector/config/manifests/whisper_gaudi.yaml
@@ -8,10 +8,10 @@ kind: ConfigMap
 metadata:
   name: whisper-config
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 data:
   EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
@@ -31,10 +31,10 @@ kind: Service
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -56,10 +56,10 @@ kind: Deployment
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-0.9.0
+    helm.sh/chart: whisper-1.0.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
-    app.kubernetes.io/version: "v0.9"
+    app.kubernetes.io/version: "v1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/microservices-connector/helm/Chart.yaml
+++ b/microservices-connector/helm/Chart.yaml
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8"
+appVersion: "v1.0"

--- a/microservices-connector/helm/values.yaml
+++ b/microservices-connector/helm/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: opea/gmcmanager
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

Switch to use latest opea image tag on main branch, and use `manual-freeze-tag` action to replace with tag version.

Manually set helm version and appVersion for the incoming v1.0 release.

## Issues

issue #341

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
