### PR TITLE
E2E: exclude terminating pods when wait_util_all_pod_ready

### DIFF
--- a/.github/workflows/scripts/e2e/gmc_xeon_test.sh
+++ b/.github/workflows/scripts/e2e/gmc_xeon_test.sh
@@ -152,7 +152,7 @@ function validate_audioqa() {
    accessUrl=$(kubectl get gmc -n $AUDIOQA_NAMESPACE -o jsonpath="{.items[?(@.metadata.name=='audioqa')].status.accessUrl}")
    byte_str=$(kubectl exec "$CLIENT_POD" -n $AUDIOQA_NAMESPACE -- curl $accessUrl -s -X POST  -d '{"byte_str": "UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA", "parameters":{"max_new_tokens":64, "do_sample": true, "streaming":false}}' -H 'Content-Type: application/json' | jq .byte_str)
    if [ -z "$byte_str" ]; then
-       echo "audioqa failed, please check the the!"
+       echo "audioqa failed!"
        exit 1
    fi
    echo "Audioqa response check succeed!"

--- a/.github/workflows/scripts/e2e/utils.sh
+++ b/.github/workflows/scripts/e2e/utils.sh
@@ -54,7 +54,7 @@ function wait_until_all_pod_ready() {
   timeout=$2
 
   echo "Wait for all pods in NS $namespace to be ready..."
-  pods=$(kubectl get pods -n $namespace --no-headers -o custom-columns=":metadata.name")
+  pods=$(kubectl get pods -n $namespace --no-headers | grep -v "Terminating" | awk '{print $1}')
   # Loop through each pod
   echo "$pods" | while read -r line; do
     pod_name=$line


### PR DESCRIPTION
## Description

When wait_util_all_pod_ready is executed and there are pods being deleted, the wait_util_all_pod_ready count all the pods including Terminating pods and wait them to be ready, which could never happen.

Solution: exclude the terminating pods when collecting the pods names.

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

 `n/a`.

## Tests

covered by CI/CD
