### PR TITLE
helm-chart/data-prep: Add the missing config for dataprep-redis

### DIFF
--- a/helm-charts/common/data-prep/templates/configmap.yaml
+++ b/helm-charts/common/data-prep/templates/configmap.yaml
@@ -20,6 +20,8 @@ data:
   REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db:6379"
   {{- end }}
   INDEX_NAME: {{ .Values.INDEX_NAME | quote }}
+  KEY_INDEX_NAME: {{ .Values.KEY_INDEX_NAME | quote }}
+  SEARCH_BATCH_SIZE: {{ .Values.SEARCH_BATCH_SIZE | quote }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
   HF_HOME: "/tmp/.cache/huggingface"
   {{- if .Values.global.HF_ENDPOINT }}

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -88,6 +88,8 @@ EMBED_MODEL: ""
 # redis DB service URL, e.g. redis://<service-name>:<port>
 REDIS_URL: ""
 INDEX_NAME: "rag-redis"
+KEY_INDEX_NAME: "file-keys"
+SEARCH_BATCH_SIZE: 10
 
 global:
   http_proxy: ""

--- a/microservices-connector/config/manifests/data-prep.yaml
+++ b/microservices-connector/config/manifests/data-prep.yaml
@@ -18,6 +18,8 @@ data:
   EMBED_MODEL: ""
   REDIS_URL: "redis://data-prep-redis-vector-db:6379"
   INDEX_NAME: "rag-redis"
+  KEY_INDEX_NAME: "file-keys"
+  SEARCH_BATCH_SIZE: "10"
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   HF_HOME: "/tmp/.cache/huggingface"
   http_proxy: ""


### PR DESCRIPTION
There are some config missing but required by get_file/delete_file API, add them for functional usage.

To fix #373 