### PR TITLE
fix GMC crashes in e2e 

### DIFF
--- a/microservices-connector/internal/controller/gmconnector_controller.go
+++ b/microservices-connector/internal/controller/gmconnector_controller.go
@@ -825,12 +825,12 @@ func isDeploymentStatusChanged(e event.UpdateEvent) bool {
 	}
 
 	if len(newDeployment.OwnerReferences) == 0 {
-		// fmt.Printf("| %s:%s: no owner reference |\n", newDeployment.Namespace, newDeployment.Name)
+		fmt.Printf("| %s:%s: no owner reference |\n", newDeployment.Namespace, newDeployment.Name)
 		return false
 	} else {
 		for _, owner := range newDeployment.OwnerReferences {
 			if owner.Kind == "GMConnector" {
-				// fmt.Printf("| %s:%s: owner is GMConnector |\n", newDeployment.Namespace, newDeployment.Name)
+				fmt.Printf("| %s:%s: owner is GMConnector |\n", newDeployment.Namespace, newDeployment.Name)
 				break
 			}
 		}

--- a/microservices-connector/internal/controller/gmconnector_controller.go
+++ b/microservices-connector/internal/controller/gmconnector_controller.go
@@ -880,6 +880,12 @@ func (r *GMConnectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Predicate to only trigger on status changes for Deployment
 	deploymentFilter := predicate.Funcs{
 		UpdateFunc: isDeploymentStatusChanged,
+		//ignore create and delete events, otherwise it will trigger the nested reconcile which is meaningless
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		}, DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/microservices-connector/internal/controller/gmconnector_controller.go
+++ b/microservices-connector/internal/controller/gmconnector_controller.go
@@ -474,6 +474,9 @@ func (r *GMConnectorReconciler) deleteRecordedResource(key string, ctx context.C
 }
 
 func (r *GMConnectorReconciler) collectResourceStatus(graph *mcv1alpha3.GMConnector, ctx context.Context) error {
+	if graph == nil || len(graph.Status.Annotations) == 0 {
+		return errors.New("graph is empty or no annotations")
+	}
 	var totalCnt uint = 0
 	var readyCnt uint = 0
 	for resName := range graph.Status.Annotations {
@@ -825,12 +828,12 @@ func isDeploymentStatusChanged(e event.UpdateEvent) bool {
 	}
 
 	if len(newDeployment.OwnerReferences) == 0 {
-		fmt.Printf("| %s:%s: no owner reference |\n", newDeployment.Namespace, newDeployment.Name)
+		// fmt.Printf("| %s:%s: no owner reference |\n", newDeployment.Namespace, newDeployment.Name)
 		return false
 	} else {
 		for _, owner := range newDeployment.OwnerReferences {
 			if owner.Kind == "GMConnector" {
-				fmt.Printf("| %s:%s: owner is GMConnector |\n", newDeployment.Namespace, newDeployment.Name)
+				// fmt.Printf("| %s:%s: owner is GMConnector |\n", newDeployment.Namespace, newDeployment.Name)
 				break
 			}
 		}


### PR DESCRIPTION
## Description

fix for #394 

**Root cause analysis:**

this issue is introduced by #383 , in this PR, I moved the deployment filters, but missed the 
```
		CreateFunc: func(e event.CreateEvent) bool {
			return false
		}, DeleteFunc: func(e event.DeleteEvent) bool {
			return false
		},
```
without these two, the creation/deletion of the deployment triggers the reconcile, 

the sequence to hit this issue is like: delete GMC pipeline -> trigger deployment deletion ->trigger graph status update, but graph is already deleted ->panic.

**solution：**

- restore the create/delete filters
- add protection code

## Issues

#394 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

CI/CD cover the tests
