### PR TITLE
Add topologySpreadConstraints support

### DIFF
--- a/helm-charts/chatqna/templates/deployment.yaml
+++ b/helm-charts/chatqna/templates/deployment.yaml
@@ -84,3 +84,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "chatqna.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/codegen/templates/deployment.yaml
+++ b/helm-charts/codegen/templates/deployment.yaml
@@ -78,3 +78,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "codegen.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/codetrans/templates/deployment.yaml
+++ b/helm-charts/codetrans/templates/deployment.yaml
@@ -66,3 +66,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "codetrans.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/asr/templates/deployment.yaml
+++ b/helm-charts/common/asr/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "asr.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/chatqna-ui/templates/deployment.yaml
+++ b/helm-charts/common/chatqna-ui/templates/deployment.yaml
@@ -65,3 +65,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "chatqna-ui.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "data-prep.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "embedding-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/guardrails-usvc/templates/deployment.yaml
+++ b/helm-charts/common/guardrails-usvc/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "guardrails-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "llm-uservice.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/redis-vector-db/templates/deployment.yaml
+++ b/helm-charts/common/redis-vector-db/templates/deployment.yaml
@@ -74,3 +74,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "redis-vector-db.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "reranking-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "retriever-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/speecht5/templates/deployment.yaml
+++ b/helm-charts/common/speecht5/templates/deployment.yaml
@@ -94,3 +94,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "speecht5.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -109,3 +109,12 @@ spec:
       # extra time to finish processing buffered requests before HPA forcibly terminates pod
       terminationGracePeriodSeconds: 60
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "tei.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -109,3 +109,12 @@ spec:
       # extra time to finish processing buffered requests before HPA forcibly terminates pod
       terminationGracePeriodSeconds: 60
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "teirerank.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -113,3 +113,12 @@ spec:
       # extra time to finish processing buffered requests before HPA forcibly terminates pod
       terminationGracePeriodSeconds: 120
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "tgi.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/tts/templates/deployment.yaml
+++ b/helm-charts/common/tts/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "tts.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/vllm/templates/deployment.yaml
+++ b/helm-charts/common/vllm/templates/deployment.yaml
@@ -114,3 +114,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "vllm.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/web-retriever/templates/deployment.yaml
+++ b/helm-charts/common/web-retriever/templates/deployment.yaml
@@ -77,3 +77,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "web-retriever.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/whisper/templates/deployment.yaml
+++ b/helm-charts/common/whisper/templates/deployment.yaml
@@ -94,3 +94,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "whisper.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/docsum/templates/deployment.yaml
+++ b/helm-charts/docsum/templates/deployment.yaml
@@ -66,3 +66,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "docsum.selectorLabels" . | nindent 14 }}
+      {{- end }}


### PR DESCRIPTION
User can set evenly_distributed true to have the pods distribute evenly.

## Issues

Closed #401 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

