### PR TITLE
Make all xeon tgi image version consistent

### DIFF
--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -26,7 +26,8 @@ image:
   repository: ghcr.io/huggingface/text-generation-inference
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.2.0"
+  # `sha-e4201f4-intel-cpu` is the image tag for intel cpu optimized tgi image
+  tag: "sha-e4201f4-intel-cpu"
 
 # empty for CPU
 accelDevice: ""

--- a/microservices-connector/config/manifests/tgi.yaml
+++ b/microservices-connector/config/manifests/tgi.yaml
@@ -87,7 +87,7 @@ spec:
                 optional: true
           securityContext:
             {}
-          image: "ghcr.io/huggingface/text-generation-inference:2.2.0"
+          image: "ghcr.io/huggingface/text-generation-inference:sha-e4201f4-intel-cpu"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /data

--- a/microservices-connector/config/samples/ChatQnA/use_cases.md
+++ b/microservices-connector/config/samples/ChatQnA/use_cases.md
@@ -19,7 +19,7 @@ The ChatQnA uses the below prebuilt images if you choose a Xeon deployment
 - dataprep-redis: opea/dataprep-redis:latest
 - tei_xeon_service: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
 - tei_embedding_service: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
-- tgi-service: ghcr.io/huggingface/text-generation-inference:2.2.0
+- tgi-service: ghcr.io/huggingface/text-generation-inference:sha-e4201f4-intel-cpu
 - redis-vector-db: redis/redis-stack:7.2.0-v9
 
 Should you desire to use the Gaudi accelerator, two alternate images are used for the embedding and llm services.


### PR DESCRIPTION
## Description

Make all xeon tgi image version consistent.
`ghcr.io/huggingface/text-generation-inference:sha-e4201f4-intel-cpu` is intel cpu optimized tgi image, we need to use this one for all xeon platform.

## Issues

`n/a`.
Related to [PR#851](https://github.com/opea-project/GenAIExamples/pull/851)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`

## Tests

`n/a`
