### PR TITLE
doc: fix missing references to README.md

### DIFF
--- a/LEGAL_INFORMATION.md
+++ b/LEGAL_INFORMATION.md
@@ -9,7 +9,7 @@ Generative AI Examples is licensed under [Apache License Version 2.0](http://www
 This software includes components that have separate copyright notices and licensing terms.
 Your use of the source code for these components is subject to the terms and conditions of the following licenses.
 
-See the accompanying [license](/LICENSE) file for full license text and copyright notices.
+See the accompanying [license](LICENSE) file for full license text and copyright notices.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ Once you have deployed GMC in your Kubernetes cluster, you can deploy any of the
 
 To deploy GenAIExamples to Kubernetes using helm charts, you need [Helm](https://helm.sh/docs/intro/install/) installed on your machine.
 
-For a detailed version, see [Deploy GenAIExample/GenAIComps using helm charts](https://github.com/opea-project/GenAIInfra/tree/main/helm-charts)
+For a detailed version, see [Deploy GenAIExample/GenAIComps using helm charts](https://github.com/opea-project/GenAIInfra/tree/main/helm-charts/README.md)
 
 ## Additional Content
 
 - [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)
 - [Contribution](https://github.com/opea-project/docs/tree/main/community/CONTRIBUTING.md)
 - [Security Policy](https://github.com/opea-project/docs/tree/main/community/SECURITY.md)
-- [Legal Information](/LEGAL_INFORMATION.md)
+- [Legal Information](LEGAL_INFORMATION.md)

--- a/helm-charts/HPA.md
+++ b/helm-charts/HPA.md
@@ -37,7 +37,7 @@ unless rules have been added to pods preventing them from being scheduled on sam
 small requests would be an issue:
 
 - Multiple inferencing instances interfere / slow down each other, especially if there are no
-  [NRI policies](https://github.com/opea-project/GenAIEval/tree/main/doc/platform-optimization)
+  [NRI policies](https://github.com/opea-project/GenAIEval/tree/main/doc/platform-optimization/README.md)
   that provide further isolation
 - Containers can become non-functional when their actual resource usage crosses the specified limits
 

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -25,10 +25,10 @@ AI application examples you can run directly on Xeon and Gaudi. You can also ref
 
 | Helm chart               | Link to GenAIExamples                                                                    | Description                                                                                     |
 | ------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [codegen](./codegen)     | [Code Generation](https://github.com/opea-project/GenAIExamples/tree/main/CodeGen)       | An example of copilot designed for code generation in Visual Studio Code.                       |
-| [codetrans](./codetrans) | [Code Translation](https://github.com/opea-project/GenAIExamples/tree/main/CodeTrans)    | An example of programming language code translation.                                            |
-| [chatqna](./chatqna)     | [ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA)               | An example of chatbot for question and answering through retrieval argumented generation (RAG). |
-| [docsum](./docsum)       | [Document Summarization](https://github.com/opea-project/GenAIExamples/tree/main/DocSum) | An example of document summarization.                                                           |
+| [codegen](./codegen/README.md)     | [Code Generation](https://github.com/opea-project/GenAIExamples/tree/main/CodeGen/README.md)       | An example of copilot designed for code generation in Visual Studio Code.                       |
+| [codetrans](./codetrans/README.md) | [Code Translation](https://github.com/opea-project/GenAIExamples/tree/main/CodeTrans/README.md)    | An example of programming language code translation.                                            |
+| [chatqna](./chatqna/README.md)     | [ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/README.md)               | An example of chatbot for question and answering through retrieval argumented generation (RAG). |
+| [docsum](./docsum/README.md)       | [Document Summarization](https://github.com/opea-project/GenAIExamples/tree/main/DocSum/README.md) | An example of document summarization.                                                           |
 
 ### Components
 

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -23,8 +23,8 @@ List of supported workloads and components.
 
 AI application examples you can run directly on Xeon and Gaudi. You can also refer to these examples to develop your own customized AI application.
 
-| Helm chart               | Link to GenAIExamples                                                                    | Description                                                                                     |
-| ------------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Helm chart                         | Link to GenAIExamples                                                                              | Description                                                                                     |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [codegen](./codegen/README.md)     | [Code Generation](https://github.com/opea-project/GenAIExamples/tree/main/CodeGen/README.md)       | An example of copilot designed for code generation in Visual Studio Code.                       |
 | [codetrans](./codetrans/README.md) | [Code Translation](https://github.com/opea-project/GenAIExamples/tree/main/CodeTrans/README.md)    | An example of programming language code translation.                                            |
 | [chatqna](./chatqna/README.md)     | [ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/README.md)               | An example of chatbot for question and answering through retrieval argumented generation (RAG). |

--- a/helm-charts/chatqna/README.md
+++ b/helm-charts/chatqna/README.md
@@ -2,15 +2,15 @@
 
 Helm chart for deploying ChatQnA service. ChatQnA depends on the following services:
 
-- [data-prep](../common/data-prep)
-- [embedding-usvc](../common/embedding-usvc)
-- [tei](../common/tei)
-- [retriever-usvc](../common/retriever-usvc)
-- [redis-vector-db](../common/redis-vector-db)
-- [reranking-usvc](../common/reranking-usvc)
-- [teirerank](../common/teirerank)
-- [llm-uservice](../common/llm-uservice)
-- [tgi](../common/tgi)
+- [data-prep](../common/data-prep/README.md)
+- [embedding-usvc](../common/embedding-usvc/README.md)
+- [tei](../common/tei/README.md)
+- [retriever-usvc](../common/retriever-usvc/README.md)
+- [redis-vector-db](../common/redis-vector-db/README.md)
+- [reranking-usvc](../common/reranking-usvc/README.md)
+- [teirerank](../common/teirerank/README.md)
+- [llm-uservice](../common/llm-uservice/README.md)
+- [tgi](../common/tgi/README.md)
 
 ## Installing the Chart
 

--- a/helm-charts/chatqna/troubleshooting.md
+++ b/helm-charts/chatqna/troubleshooting.md
@@ -1,9 +1,9 @@
-## ChatQnA Troubleshooting
+# ChatQnA Troubleshooting
 
 After deploying chatqna with helm chart, we can use the following command to check whether each service is working properly.
 These commands show the steps how RAG work with LLM.
 
-### a function to get the endpoint of service
+## a function to get the endpoint of service
 
 This is a based command to get each service endpoint of chatqna components.
 
@@ -14,7 +14,7 @@ svc_endpoint() {
 }
 ```
 
-### define the namespace of service
+## define the namespace of service
 
 Please specify the namespace of chatqna, it will be **default** if not define.
 
@@ -41,7 +41,7 @@ orchestrator-system           Active   21d
 tigera-operator               Active   21d
 ```
 
-### Update a file to database
+## Update a file to database
 
 This step will upload a pdf about nike revenue information to vector database.
 
@@ -66,7 +66,7 @@ curl -x "" -X POST "http://${endpoint}/v1/dataprep" \
 >
 > you can use **grep** to filter the labels by key.
 
-### get the embedding of input
+## get the embedding of input
 
 This step will get the embedding of your input/question.
 
@@ -83,7 +83,7 @@ your_embedding=$(curl -x "" http://${endpoint}/embed \
     -H 'Content-Type: application/json' |jq .[0] -c)
 ```
 
-### get the retriever docs
+## get the retriever docs
 
 This step will get related docs related to your input/question.
 
@@ -100,7 +100,7 @@ retrieved_docs=$(curl -x "" http://${endpoint}/v1/retrieval \
   -H 'Content-Type: application/json' | jq -c .retrieved_docs)
 ```
 
-### reranking the docs
+## reranking the docs
 
 This step will get related docs most relevant to your input/question.
 
@@ -121,7 +121,7 @@ reranking_docs=$(sed 's/\\"/ /g' <<< "${reranking_docs}")
 reranking_docs=$(tr -d '"' <<< "${reranking_docs}")
 ```
 
-### TGI Q and A
+## TGI Q and A
 
 This step will render the answer of your question.
 
@@ -148,6 +148,6 @@ The output
 {"generated_text":" In fiscal 2023, NIKE, Inc. achieved record Revenues of $51.2 billion."}
 ```
 
-### REF
+## REF
 
-[Build Mega Service of ChatQnA on Xeon](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/docker_compose/intel/cpu/xeon)
+[Build Mega Service of ChatQnA on Xeon](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/docker_compose/intel/cpu/xeon/README.md)

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for deploying CodeGen service.
 
-CodeGen depends on LLM and tgi microservice, refer to [llm-uservice](../common/llm-uservice) and [tgi](../common/tgi) for more config details.
+CodeGen depends on LLM and tgi microservice, refer to [llm-uservice](../common/llm-uservice/README.md) and [tgi](../common/tgi/README.md) for more config details.
 
 ## Installing the Chart
 

--- a/helm-charts/common/asr/README.md
+++ b/helm-charts/common/asr/README.md
@@ -6,7 +6,7 @@ asr depends on whisper, you should set ASR_ENDPOINT endpoints before start.
 
 ## (Option1): Installing the chart separately
 
-First, you need to install the whisper chart, please refer to the [whisper](../whisper) chart for more information.
+First, you need to install the whisper chart, please refer to the [whisper](../whisper/README.md) chart for more information.
 
 After you've deployted the whisper chart successfully, please run `kubectl get svc` to get the whisper service endpoint, i.e `http://whisper:7066`.
 

--- a/helm-charts/common/data-prep/README.md
+++ b/helm-charts/common/data-prep/README.md
@@ -6,7 +6,7 @@ data-prep will use redis and tei service, please specify the endpoints.
 
 ## (Option1): Installing the chart separately
 
-First, you need to install the tei and redis-vector-db chart, please refer to the [tei](../tei) and [redis-vector-db](../redis-vector-db) for more information.
+First, you need to install the tei and redis-vector-db chart, please refer to the [tei](../tei/README.md) and [redis-vector-db](../redis-vector-db/README.md) for more information.
 
 After you've deployted the tei and redis-vector-db chart successfully, please run `kubectl get svc` to get the service endpoint and URL respectively, i.e. `http://tei`, `redis://redis-vector-db:6379`.
 

--- a/helm-charts/common/retriever-usvc/README.md
+++ b/helm-charts/common/retriever-usvc/README.md
@@ -6,7 +6,7 @@ retriever-usvc depends on redis and tei, you should set these endpoints before s
 
 ## (Option1): Installing the chart separately
 
-First, you need to install the tei and redis-vector-db chart, refer to the [tei](../tei) and [redis-vector-db](../redis-vector-db) for more information.
+First, you need to install the tei and redis-vector-db chart, refer to the [tei](../tei/README.md) and [redis-vector-db](../redis-vector-db/README.md) for more information.
 
 After you've deployed the tei and redis-vector-db chart successfully, run `kubectl get svc` to get the service endpoint and URL respectively, i.e. `http://tei`, `redis://redis-vector-db:6379`.
 

--- a/kubernetes-addons/Observability/README.md
+++ b/kubernetes-addons/Observability/README.md
@@ -104,7 +104,7 @@ To monitor ChatQnA metrics including TGI-gaudi,TEI,TEI-Reranking and other micro
 
 Install Helm (version >= 3.15) first. Refer to the [Helm Installation Guide](https://helm.sh/docs/intro/install/) for more information.
 
-Refer to the [ChatQnA helm chart](https://github.com/opea-project/GenAIInfra/tree/main/helm-charts/chatqna) for instructions on deploying ChatQnA into Kubernetes on Xeon & Gaudi.
+Refer to the [ChatQnA helm chart](https://github.com/opea-project/GenAIInfra/tree/main/helm-charts/chatqna/README.md) for instructions on deploying ChatQnA into Kubernetes on Xeon & Gaudi.
 
 ### Step 2: Install all the serviceMonitor
 

--- a/microservices-connector/config/samples/ChatQnA/use_cases.md
+++ b/microservices-connector/config/samples/ChatQnA/use_cases.md
@@ -4,7 +4,7 @@ This document outlines the deployment process for a ChatQnA application utilizin
 
 The ChatQnA Service leverages a Kubernetes operator called genai-microservices-connector(GMC). GMC supports connecting microservices to create pipelines based on the specification in the pipeline yaml file in addition to allowing the user to dynamically control which model is used in a service such as an LLM or embedder. The underlying pipeline language also supports using external services that may be running in public or private cloud elsewhere.
 
-Install GMC in your Kubernetes cluster, if you have not already done so, by following the steps in Section "Getting Started" at [GMC Install](https://github.com/opea-project/GenAIInfra/tree/main/microservices-connector). Soon as we publish images to Docker Hub, at which point no builds will be required, simplifying install.
+Install GMC in your Kubernetes cluster, if you have not already done so, by following the steps in Section "Getting Started" at [GMC Install](https://github.com/opea-project/GenAIInfra/tree/main/microservices-connector/README.md). Soon as we publish images to Docker Hub, at which point no builds will be required, simplifying install.
 
 The ChatQnA application is defined as a Custom Resource (CR) file that the above GMC operator acts upon. It first checks if the microservices listed in the CR yaml file are running, if not starts them and then proceeds to connect them. When the ChatQnA RAG pipeline is ready, the service endpoint details are returned, letting you use the application. Should you use "kubectl get pods" commands you will see all the component microservices, in particular `embedding`, `retriever`, `rerank`, and `llm`.
 

--- a/microservices-connector/troubleshooting_guide.md
+++ b/microservices-connector/troubleshooting_guide.md
@@ -17,7 +17,7 @@ After the CR for GMC pipeline has been deployed, correct the CR if you encounter
    The GMCConnector "chatqa" is invalid: spec.nodes.root.steps[0].name: Invalid value: v1alpha3.Step{StepName:"Embedding123", Executor:v1alpha3.Executor{NodeName:"", InternalService:v1alpha3.GMCTarget{ServiceName:"embedding-svc", NameSpace:"", Config:map[string]string{"TEI_EMBEDDING_ENDPOINT":"tei-embedding-svc", "endpoint":"/v1/embeddings"}, IsDownstreamService:false}, ExternalService:""}, Data:"", Condition:"", Dependency:"", ServiceURL:""}: invalid step name: Embedding123 for node root
    ```
 
-   In the CR, the value of StepName in the `spec.nodes.<nodeName>.steps[].name` field should be included in the predefined [list](./api/v1alpha3/validating_webhook.go).
+   In the CR, the value of StepName in the `spec.nodes.<nodeName>.steps[].name` field should be included in the predefined [list](https://github.com/opea-project/GenAIInfra/blob/main/microservices-connector/api/v1alpha3/validating_webhook.go).
 
 3. nodeName existence
 


### PR DESCRIPTION
Cross-repo references using an URL that only has the folder name cause links in the github.io site to go to the github.com site.  Most of these uses want to link to the documentation (README.md) so add that where appropriate so links in the github.io site stay there.
