### PR TITLE
Add helm chart for 3 components

### DIFF
--- a/helm-charts/common/chathistory-usvc/.helmignore
+++ b/helm-charts/common/chathistory-usvc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/common/chathistory-usvc/Chart.yaml
+++ b/helm-charts/common/chathistory-usvc/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: chathistory-usvc
+description: The Helm chart for deploying chat history as microservice
+type: application
+version: 1.0.0
+# The chat history microservice server version
+appVersion: "v1.0"
+dependencies:
+  - name: mongodb
+    version: 1.0.0
+    repository: file://../mongodb
+    condition: autodependency.enabled

--- a/helm-charts/common/chathistory-usvc/README.md
+++ b/helm-charts/common/chathistory-usvc/README.md
@@ -1,0 +1,54 @@
+# chathistory-usvc
+
+Helm chart for deploying chathistory-usvc microservice.
+
+chathistory-usvc will use redis and tei service, please specify the endpoints.
+
+## (Option1): Installing the chart separately
+
+First, you need to install the mongodb chart, please refer to the [mongodb](../mongodb) for more information.
+
+After you've deployted the mongodb chart successfully, run `kubectl get svc` to get the service endpoint and URL respectively, i.e. `mongodb:27017`.
+
+To install chathistory-usvc chart, run the following:
+
+```console
+cd GenAIInfra/helm-charts/common/chathistory-usvc
+export MONGO_HOST="mongodb"
+export MONGO_PORT="27017"
+helm dependency update
+helm install chathistory-usvc . --set MONGO_HOST=${MONGO_HOST} --set MONGO_PORT=${MONGO_PORT}
+```
+
+## (Option2): Installing the chart with dependencies automatically
+
+```console
+cd GenAIInfra/helm-charts/common/chathistory-usvc
+helm dependency update
+helm install chathistory-usvc . --set autodependency.enabled=true
+```
+
+## Verify
+
+To verify the installation, run the command `kubectl get pod` to make sure all pods are running.
+
+Then run the command `kubectl port-forward svc/chathistory-usvc 6012:6012` to expose the chathistory-usvc service for access.
+
+Open another terminal and run the following command to verify the service if working:
+
+```console
+curl -X 'POST' \
+  http://localhost:6012/v1/chathistory/create \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{"data": {"messages": "test Messages", "user": "test"}}'
+```
+
+## Values
+
+| Key              | Type   | Default                           | Description |
+| ---------------- | ------ | --------------------------------- | ----------- |
+| image.repository | string | `"opea/chathistory-mongo-server"` |             |
+| service.port     | string | `"6012"`                          |             |
+| MONGO_HOST       | string | `""`                              |             |
+| MONGO_PORT       | string | `""`                              |             |

--- a/helm-charts/common/chathistory-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/chathistory-usvc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chathistory-usvc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chathistory-usvc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chathistory-usvc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chathistory-usvc.labels" -}}
+helm.sh/chart: {{ include "chathistory-usvc.chart" . }}
+{{ include "chathistory-usvc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chathistory-usvc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chathistory-usvc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chathistory-usvc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chathistory-usvc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/common/chathistory-usvc/templates/configmap.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/configmap.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "chathistory-usvc.fullname" . }}-config
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+data:
+  {{- if .Values.MONGO_HOST }}
+  MONGO_HOST: {{ .Values.MONGO_HOST | quote}}
+  {{- else }}
+  MONGO_HOST: "{{ .Release.Name }}-mongodb"
+  {{- end }}
+  {{- if .Values.MONGO_PORT }}
+  MONGO_PORT: {{ .Values.MONGO_PORT | quote }}
+  {{- else }}
+  MONGO_PORT: "27017"
+  {{- end }}
+  DB_NAME: {{ .Values.DB_NAME | quote }}
+  COLLECTION_NAME: {{ .Values.COLLECTION_NAME | quote }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  {{- if and (not .Values.MONGO_HOST) (or .Values.global.http_proxy .Values.global.https_proxy) }}
+  no_proxy: "{{ .Release.Name }}-mongodb,{{ .Values.global.no_proxy }}"
+  {{- else }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  {{- end }}
+  LOGFLAG: {{ .Values.LOGFLAG | quote }}

--- a/helm-charts/common/chathistory-usvc/templates/deployment.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/deployment.yaml
@@ -1,0 +1,88 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chathistory-usvc.fullname" . }}
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chathistory-usvc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chathistory-usvc.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Release.Name }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "chathistory-usvc.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: port
+              containerPort: 6012
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "chathistory-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/chathistory-usvc/templates/service.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chathistory-usvc.fullname" . }}
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 6012
+      protocol: TCP
+      name: port
+  selector:
+    {{- include "chathistory-usvc.selectorLabels" . | nindent 4 }}

--- a/helm-charts/common/chathistory-usvc/templates/tests/test-pod.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/tests/test-pod.yaml
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "chathistory-usvc.fullname" . }}-testpod
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    #"helm.sh/hook-delete-policy": "hook-succeeded, hook-failure"
+spec:
+  containers:
+    - name: curl
+      image: python:3.10.14
+      command: ['bash', '-c']
+      args:
+        - |
+          set -x
+          max_retry=20;
+          for ((i=1; i<=max_retry; i++)); do
+            curl -X 'POST' \
+              http://{{ include "chathistory-usvc.fullname" . }}:{{ .Values.service.port }}/v1/chathistory/create -sS --fail-with-body \
+              -H 'accept: application/json' \
+              -H 'Content-Type: application/json' \
+              -d '{"data": {"messages": "test Messages", "user": "test"}}' && break;
+            curlcode=$?
+            if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;
+          done;
+          if [ $i -gt $max_retry ]; then echo "test failed with maximum retry"; exit 1; fi
+  restartPolicy: Never

--- a/helm-charts/common/chathistory-usvc/values.yaml
+++ b/helm-charts/common/chathistory-usvc/values.yaml
@@ -1,0 +1,95 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for chathistory-usvc.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+autodependency:
+  enabled: false
+
+replicaCount: 1
+
+image:
+  repository: opea/chathistory-mongo-server
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  port: 6012
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 24
+readinessProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+startupProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 120
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Set it as a non-null string, such as true, if you want to enable logging facility,
+# otherwise, keep it as "" to disable it.
+LOGFLAG: ""
+
+# MongoDB info
+MONGO_HOST: ""
+MONGO_PORT: ""
+DB_NAME: "OPEA"
+COLLECTION_NAME: "ChatHistory"
+
+global:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/helm-charts/common/mongodb/.helmignore
+++ b/helm-charts/common/mongodb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/common/mongodb/Chart.yaml
+++ b/helm-charts/common/mongodb/Chart.yaml
@@ -1,0 +1,9 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: mongodb
+description: The Helm chart for Redis Vector DB
+type: application
+version: 1.0.0
+appVersion: "7.0.11"

--- a/helm-charts/common/mongodb/README.md
+++ b/helm-charts/common/mongodb/README.md
@@ -1,0 +1,28 @@
+# mongodb
+
+Helm chart for deploying mongo DB service.
+
+## Install the Chart
+
+To install the chart, run the following:
+
+```console
+cd ${GenAIInfro_repo}/helm-charts/common
+helm install mongodb mongodb
+```
+
+## Verify
+
+To verify the installation, run the command `kubectl get pod` to make sure all the mongo pods are runinng.
+
+Then run the command `kubectl port-forward svc/mongodb 27017:27017` to expose the mongodb service for access.
+
+Open another terminal and run the command `mongo --eval 'db.runCommand("ping").ok' localhost:27017/test --quiet ` to test mongodb access. The `mongo` command should return `1`.
+
+## Values
+
+| Key              | Type   | Default    | Description              |
+| ---------------- | ------ | ---------- | ------------------------ |
+| image.repository | string | `"mongo"`  |                          |
+| image.tag        | string | `"7.0.11"` |                          |
+| service.port     | string | `"27017"`  | The mongodb service port |

--- a/helm-charts/common/mongodb/templates/_helpers.tpl
+++ b/helm-charts/common/mongodb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mongodb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mongodb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mongodb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mongodb.labels" -}}
+helm.sh/chart: {{ include "mongodb.chart" . }}
+{{ include "mongodb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mongodb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mongodb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mongodb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mongodb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/common/mongodb/templates/deployment.yaml
+++ b/helm-charts/common/mongodb/templates/deployment.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mongodb.fullname" . }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mongodb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mongodb.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /data
+              name: data-volume
+            - mountPath: /tmp
+              name: tmp
+          ports:
+            - name: port
+              containerPort: 27017
+              protocol: TCP
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "mongodb.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/mongodb/templates/service.yaml
+++ b/helm-charts/common/mongodb/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mongodb.fullname" . }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 27017
+      protocol: TCP
+      name: mongodb
+  selector:
+    {{- include "mongodb.selectorLabels" . | nindent 4 }}

--- a/helm-charts/common/mongodb/templates/tests/test-pod.yaml
+++ b/helm-charts/common/mongodb/templates/tests/test-pod.yaml
@@ -1,0 +1,22 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "mongodb.fullname" . }}-testpod
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    #"helm.sh/hook-delete-policy": "hook-succeeded, hook-failure"
+spec:
+  containers:
+    - name: mongoclient
+      image: mongoclient/mongoclient:latest
+      command: ['sh', '-c']
+      args:
+        - |
+          set -x
+          mongo --eval 'db.runCommand("ping").ok' {{ include "mongodb.fullname" . }}:{{ .Values.service.port }}/test --quiet
+  restartPolicy: Never

--- a/helm-charts/common/mongodb/values.yaml
+++ b/helm-charts/common/mongodb/values.yaml
@@ -1,0 +1,61 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+image:
+  repository: mongo
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "7.0.11"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: false
+  runAsUser: 999
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  port: 27017
+
+startupProbe:
+  tcpSocket:
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 120
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm-charts/common/prompt-usvc/.helmignore
+++ b/helm-charts/common/prompt-usvc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/common/prompt-usvc/Chart.yaml
+++ b/helm-charts/common/prompt-usvc/Chart.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: prompt-usvc
+description: The Helm chart for deploying prompt as microservice
+type: application
+version: 1.0.0
+# The prompt microservice server version
+appVersion: "v1.0"
+dependencies:
+  - name: mongodb
+    version: 1.0.0
+    repository: file://../mongodb
+    condition: autodependency.enabled

--- a/helm-charts/common/prompt-usvc/README.md
+++ b/helm-charts/common/prompt-usvc/README.md
@@ -1,0 +1,54 @@
+# prompt-usvc
+
+Helm chart for deploying prompt-usvc microservice.
+
+prompt-usvc will use mongo database service, please specify the endpoints.
+
+## (Option1): Installing the chart separately
+
+First, you need to install the mongodb chart, please refer to the [mongodb](../mongodb) for more information.
+
+After you've deployted the mongodb chart successfully, run `kubectl get svc` to get the service endpoint and URL respectively, i.e. `mongodb:27017`.
+
+To install prompt-usvc chart, run the following:
+
+```console
+cd GenAIInfra/helm-charts/common/prompt-usvc
+export MONGO_HOST="mongodb"
+export MONGO_PORT="27017"
+helm dependency update
+helm install prompt-usvc . --set MONGO_HOST=${MONGO_HOST} --set MONGO_PORT=${MONGO_PORT}
+```
+
+## (Option2): Installing the chart with dependencies automatically
+
+```console
+cd GenAIInfra/helm-charts/common/prompt-usvc
+helm dependency update
+helm install prompt-usvc . --set autodependency.enabled=true
+```
+
+## Verify
+
+To verify the installation, run the command `kubectl get pod` to make sure all pods are running.
+
+Then run the command `kubectl port-forward svc/prompt-usvc 6018:6018` to expose the prompt-usvc service for access.
+
+Open another terminal and run the following command to verify the service if working:
+
+```console
+curl -X 'POST' \
+  http://localhost:6018/v1/prompt/create \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt_text": "test prompt", "user": "test"}';
+```
+
+## Values
+
+| Key              | Type   | Default                       | Description |
+| ---------------- | ------ | ----------------------------- | ----------- |
+| image.repository | string | `"opea/promptregistry-mongo"` |             |
+| service.port     | string | `"6018"`                      |             |
+| MONGO_HOST       | string | `""`                          |             |
+| MONGO_PORT       | string | `""`                          |             |

--- a/helm-charts/common/prompt-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/prompt-usvc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prompt-usvc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prompt-usvc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prompt-usvc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prompt-usvc.labels" -}}
+helm.sh/chart: {{ include "prompt-usvc.chart" . }}
+{{ include "prompt-usvc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prompt-usvc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prompt-usvc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prompt-usvc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prompt-usvc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/common/prompt-usvc/templates/configmap.yaml
+++ b/helm-charts/common/prompt-usvc/templates/configmap.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prompt-usvc.fullname" . }}-config
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+data:
+  {{- if .Values.MONGO_HOST }}
+  MONGO_HOST: {{ .Values.MONGO_HOST | quote}}
+  {{- else }}
+  MONGO_HOST: "{{ .Release.Name }}-mongodb"
+  {{- end }}
+  {{- if .Values.MONGO_PORT }}
+  MONGO_PORT: {{ .Values.MONGO_PORT | quote }}
+  {{- else }}
+  MONGO_PORT: "27017"
+  {{- end }}
+  DB_NAME: {{ .Values.DB_NAME | quote }}
+  COLLECTION_NAME: {{ .Values.COLLECTION_NAME | quote }}
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  {{- if and (not .Values.MONGO_HOST) (or .Values.global.http_proxy .Values.global.https_proxy) }}
+  no_proxy: "{{ .Release.Name }}-mongodb,{{ .Values.global.no_proxy }}"
+  {{- else }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  {{- end }}
+  LOGFLAG: {{ .Values.LOGFLAG | quote }}

--- a/helm-charts/common/prompt-usvc/templates/deployment.yaml
+++ b/helm-charts/common/prompt-usvc/templates/deployment.yaml
@@ -1,0 +1,88 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "prompt-usvc.fullname" . }}
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "prompt-usvc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "prompt-usvc.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Release.Name }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "prompt-usvc.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: port
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "prompt-usvc.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/prompt-usvc/templates/service.yaml
+++ b/helm-charts/common/prompt-usvc/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prompt-usvc.fullname" . }}
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.port }}
+      protocol: TCP
+      name: port
+  selector:
+    {{- include "prompt-usvc.selectorLabels" . | nindent 4 }}

--- a/helm-charts/common/prompt-usvc/templates/tests/test-pod.yaml
+++ b/helm-charts/common/prompt-usvc/templates/tests/test-pod.yaml
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "prompt-usvc.fullname" . }}-testpod
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    #"helm.sh/hook-delete-policy": "hook-succeeded, hook-failure"
+spec:
+  containers:
+    - name: curl
+      image: python:3.10.14
+      command: ['bash', '-c']
+      args:
+        - |
+          set -x
+          max_retry=20;
+          for ((i=1; i<=max_retry; i++)); do
+            curl -X 'POST' \
+              http://{{ include "prompt-usvc.fullname" . }}:{{ .Values.service.port }}/v1/prompt/create -sS --fail-with-body \
+              -H 'accept: application/json' \
+              -H 'Content-Type: application/json' \
+              -d '{"prompt_text": "test prompt", "user": "test"}' && break;
+            curlcode=$?
+            if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;
+          done;
+          if [ $i -gt $max_retry ]; then echo "test failed with maximum retry"; exit 1; fi
+  restartPolicy: Never

--- a/helm-charts/common/prompt-usvc/values.yaml
+++ b/helm-charts/common/prompt-usvc/values.yaml
@@ -1,0 +1,98 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for prompt-usvc.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+autodependency:
+  enabled: false
+
+replicaCount: 1
+
+image:
+  repository: opea/promptregistry-mongo-server
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  port: 6018
+
+# Port 6012 is reused by chathistory, will need to change after https://github.com/opea-project/GenAIComps/pull/740
+# Change this after next release untill latest image updated.
+port: 6012
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 24
+readinessProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+startupProbe:
+  httpGet:
+    path: v1/health_check
+    port: port
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 120
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Set it as a non-null string, such as true, if you want to enable logging facility,
+# otherwise, keep it as "" to disable it.
+LOGFLAG: ""
+
+# mongo DB service URL, e.g. mongo://<service-name>:<port>
+MONGO_HOST: ""
+MONGO_PORT: 27017
+DB_NAME: "OPEA"
+COLLECTION_NAME: "Prompt"
+
+global:
+  http_proxy: ""
+  https_proxy: ""
+  no_proxy: ""

--- a/helm-charts/common/prompt-usvc/values.yaml
+++ b/helm-charts/common/prompt-usvc/values.yaml
@@ -41,7 +41,7 @@ service:
   port: 6018
 
 # Port 6012 is reused by chathistory, will need to change after https://github.com/opea-project/GenAIComps/pull/740
-# Change this after next release untill latest image updated.
+# Change this after next release until latest image updated.
 port: 6012
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
ChatHistory/PromptRegistry and mongodb.

## Description

Add helm charts for 3 components

## Issues

#281 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Local build opea/promptregistry-mongo and opea/chathistory-mongo-server.
helm install and helm test