### PR TITLE
Add milvus support for data-prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 **/bin/
 *.out
+*.swp
 **/Chart.lock
 **/charts/*.tgz
 
 bazel-*
 compile_commands.json
+.gitconfig

--- a/helm-charts/common/data-prep/Chart.yaml
+++ b/helm-charts/common/data-prep/Chart.yaml
@@ -17,3 +17,7 @@ dependencies:
     version: 1.0.0
     repository: file://../redis-vector-db
     condition: redis-vector-db.enabled
+  - name: milvus
+    version: 4.2.12
+    repository: https://zilliztech.github.io/milvus-helm/
+    condition: milvus.enabled

--- a/helm-charts/common/data-prep/README.md
+++ b/helm-charts/common/data-prep/README.md
@@ -52,3 +52,7 @@ curl http://localhost:6007/v1/dataprep  \
 | service.port           | string | `"6007"`                |             |
 | REDIS_URL              | string | `""`                    |             |
 | TEI_EMBEDDING_ENDPOINT | string | `""`                    |             |
+
+## Milvus support
+
+Refer to the milvus-values.yaml for milvus configurations.

--- a/helm-charts/common/data-prep/ci-values.yaml
+++ b/helm-charts/common/data-prep/ci-values.yaml
@@ -9,3 +9,5 @@ tei:
   enabled: true
 redis-vector-db:
   enabled: true
+milvus:
+  enabled: false

--- a/helm-charts/common/data-prep/milvus-values.yaml
+++ b/helm-charts/common/data-prep/milvus-values.yaml
@@ -1,0 +1,33 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for data-prep.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+milvus:
+  enabled: true
+  cluster:
+    enabled: false
+  etcd:
+    replicaCount: 1
+  pulsar:
+    enabled: false
+  minio:
+    mode: standalone
+redis-vector-db:
+  enabled: false
+tei:
+  enabled: true
+
+image:
+  repository: opea/dataprep-milvus
+
+port: 6010
+# text embedding inference service URL, e.g. http://<service-name>:<port>
+#TEI_EMBEDDING_ENDPOINT: "http://embedding-tei:80"
+# milvus DB configurations
+#MILVUS_HOST: "milvustest"
+MILVUS_PORT: "19530"
+COLLECTION_NAME: "rag_milvus"
+MOSEC_EMBEDDING_ENDPOINT: ""
+MOSEC_EMBEDDING_MODEL: ""

--- a/helm-charts/common/data-prep/templates/configmap.yaml
+++ b/helm-charts/common/data-prep/templates/configmap.yaml
@@ -8,12 +8,19 @@ metadata:
   labels:
     {{- include "data-prep.labels" . | nindent 4 }}
 data:
-  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  {{- if .Values.MOSEC_EMBEDDING_ENDPOINT }}
+  MOSEC_EMBEDDING_ENDPOINT: {{ .Values.MOSEC_EMBEDDING_ENDPOINT | quote}}
+  MOSEC_EMBEDDING_MODEL: {{ .Values.MOSEC_EMBEDDING_MODEL | quote}}
+  {{- else if .Values.TEI_EMBEDDING_ENDPOINT }}
   TEI_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
-  {{- else if not .Values.EMBED_MODEL }}
+  TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote}}
+  {{- else if not .Values.LOCAL_EMBEDDING_MODEL }}
   TEI_ENDPOINT: "http://{{ .Release.Name }}-tei"
   {{- end }}
-  EMBED_MODEL: {{ .Values.EMBED_MODEL | quote }}
+  {{- if .Values.LOCAL_EMBEDDING_MODEL }}
+  EMBED_MODEL: {{ .Values.LOCAL_EMBEDDING_MODEL | quote }}
+  LOCAL_EMBEDDING_MODEL: {{ .Values.LOCAL_EMBEDDING_MODEL | quote }}
+  {{- end }}
   {{- if .Values.REDIS_URL }}
   REDIS_URL: {{ .Values.REDIS_URL | quote}}
   {{- else }}
@@ -22,6 +29,16 @@ data:
   INDEX_NAME: {{ .Values.INDEX_NAME | quote }}
   KEY_INDEX_NAME: {{ .Values.KEY_INDEX_NAME | quote }}
   SEARCH_BATCH_SIZE: {{ .Values.SEARCH_BATCH_SIZE | quote }}
+  {{- if .Values.MILVUS_HOST }}
+  MILVUS_HOST: {{ .Values.MILVUS_HOST | quote }}
+  {{- else }}
+  MILVUS_HOST: "{{ .Release.Name }}-milvus"
+  {{- end }}
+  MILVUS: {{ .Values.MILVUS_HOST | quote }}
+  MILVUS_PORT: {{ .Values.MILVUS_PORT | quote }}
+  {{- if .Values.COLLECTION_NAME }}
+  COLLECTION_NAME: {{ .Values.COLLECTION_NAME | quote }}
+  {{- end }}
   HUGGINGFACEHUB_API_TOKEN: {{ .Values.global.HUGGINGFACEHUB_API_TOKEN | quote}}
   HF_HOME: "/tmp/.cache/huggingface"
   {{- if .Values.global.HF_ENDPOINT }}

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: data-prep
-              containerPort: 6007
+              containerPort: {{ .Values.port }}
               protocol: TCP
           volumeMounts:
             - mountPath: /tmp

--- a/helm-charts/common/data-prep/templates/service.yaml
+++ b/helm-charts/common/data-prep/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 6007
+      targetPort: {{ .Values.port }}
       protocol: TCP
       name: data-prep
   selector:

--- a/helm-charts/common/data-prep/templates/tests/test-pod.yaml
+++ b/helm-charts/common/data-prep/templates/tests/test-pod.yaml
@@ -27,5 +27,9 @@ spec:
             curlcode=$?
             if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;
           done;
+          curl http://{{ include "data-prep.fullname" . }}:{{ .Values.service.port }}/v1/dataprep/delete_file -sS \
+          -X POST \
+          -H "Content-Type: application/json" \
+          -d '{"file_path": "file1.txt"}';
           if [ $i -gt $max_retry ]; then echo "test failed with maximum retry"; exit 1; fi
   restartPolicy: Never

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -7,6 +7,8 @@
 
 tei:
   enabled: false
+milvus:
+  enabled: false
 redis-vector-db:
   enabled: false
 
@@ -38,6 +40,7 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+port: 6007
 service:
   type: ClusterIP
   port: 6007
@@ -89,13 +92,20 @@ LOGFLAG: ""
 TEI_EMBEDDING_ENDPOINT: ""
 
 # local embedder's model
-EMBED_MODEL: ""
+LOCAL_EMBEDDING_MODEL: ""
 
 # redis DB service URL, e.g. redis://<service-name>:<port>
 REDIS_URL: ""
 INDEX_NAME: "rag-redis"
 KEY_INDEX_NAME: "file-keys"
 SEARCH_BATCH_SIZE: 10
+
+# milvus DB configurations
+MILVUS_HOST: ""
+MILVUS_PORT: ""
+COLLECTION_NAME: ""
+MOSEC_EMBEDDING_ENDPOINT: ""
+MOSEC_EMBEDDING_MODEL: ""
 
 global:
   http_proxy: ""

--- a/helm-charts/common/retriever-usvc/Chart.yaml
+++ b/helm-charts/common/retriever-usvc/Chart.yaml
@@ -17,3 +17,7 @@ dependencies:
     version: 1.0.0
     repository: file://../redis-vector-db
     condition: redis-vector-db.enabled
+  - name: milvus
+    version: 4.2.12
+    repository: https://zilliztech.github.io/milvus-helm/
+    condition: milvus.enabled

--- a/helm-charts/common/retriever-usvc/README.md
+++ b/helm-charts/common/retriever-usvc/README.md
@@ -52,3 +52,7 @@ curl http://localhost:7000/v1/retrieval  \
 | service.port           | string | `"7000"`               |             |
 | REDIS_URL              | string | `""`                   |             |
 | TEI_EMBEDDING_ENDPOINT | string | `""`                   |             |
+
+## Milvus support
+
+Refer to the milvus-values.yaml for milvus configurations.

--- a/helm-charts/common/retriever-usvc/ci-values.yaml
+++ b/helm-charts/common/retriever-usvc/ci-values.yaml
@@ -9,3 +9,5 @@ tei:
   enabled: true
 redis-vector-db:
   enabled: true
+milvus:
+  enabled: false

--- a/helm-charts/common/retriever-usvc/milvus-values.yaml
+++ b/helm-charts/common/retriever-usvc/milvus-values.yaml
@@ -1,0 +1,33 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for retriever-usvc.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+milvus:
+  enabled: true
+  cluster:
+    enabled: false
+  etcd:
+    replicaCount: 1
+  pulsar:
+    enabled: false
+  minio:
+    mode: standalone
+redis-vector-db:
+    enabled: false
+tei:
+  enabled: true
+
+image:
+  repository: opea/retriever-milvus
+port: 7000
+# text embedding inference service URL, e.g. http://<service-name>:<port>
+#TEI_EMBEDDING_ENDPOINT: "http://dataprep-tei:80"
+# milvus DB configurations
+#MILVUS_HOST: "dataprep-milvus"
+MILVUS_PORT: "19530"
+COLLECTION_NAME: "rag_milvus"
+MOSEC_EMBEDDING_ENDPOINT: ""
+MOSEC_EMBEDDING_MODEL: ""

--- a/helm-charts/common/retriever-usvc/templates/configmap.yaml
+++ b/helm-charts/common/retriever-usvc/templates/configmap.yaml
@@ -8,18 +8,34 @@ metadata:
   labels:
     {{- include "retriever-usvc.labels" . | nindent 4 }}
 data:
-  {{- if .Values.TEI_EMBEDDING_ENDPOINT }}
+  {{- if .Values.MOSEC_EMBEDDING_ENDPOINT }}
+  MOSEC_EMBEDDING_ENDPOINT: {{ .Values.MOSEC_EMBEDDING_ENDPOINT | quote}}
+  MOSEC_EMBEDDING_MODEL: {{ .Values.MOSEC_EMBEDDING_MODEL | quote}}
+  {{- else if .Values.TEI_EMBEDDING_ENDPOINT }}
   TEI_EMBEDDING_ENDPOINT: {{ .Values.TEI_EMBEDDING_ENDPOINT | quote }}
-  {{- else if not .Values.EMBED_MODEL }}
+  {{- else if not .Values.LOCAL_EMBEDDING_MODEL }}
   TEI_EMBEDDING_ENDPOINT: "http://{{ .Release.Name }}-tei"
   {{- end }}
-  EMBED_MODEL: {{ .Values.EMBED_MODEL | quote }}
+  {{- if .Values.LOCAL_EMBEDDING_MODEL }}
+  EMBED_MODEL: {{ .Values.LOCAL_EMBEDDING_MODEL | quote }}
+  LOCAL_EMBEDDING_MODEL: {{ .Values.LOCAL_EMBEDDING_MODEL | quote }}
+  {{- end }}
   {{- if .Values.REDIS_URL }}
   REDIS_URL: {{ .Values.REDIS_URL | quote}}
   {{- else }}
   REDIS_URL: "redis://{{ .Release.Name }}-redis-vector-db:6379"
   {{- end }}
   INDEX_NAME: {{ .Values.INDEX_NAME | quote }}
+  {{- if .Values.MILVUS_HOST }}
+  MILVUS_HOST: {{ .Values.MILVUS_HOST | quote }}
+  {{- else }}
+  MILVUS_HOST: "{{ .Release.Name }}-milvus"
+  {{- end }}
+  MILVUS: {{ .Values.MILVUS_HOST | quote }}
+  MILVUS_PORT: {{ .Values.MILVUS_PORT | quote }}
+  {{- if .Values.COLLECTION_NAME }}
+  COLLECTION_NAME: {{ .Values.COLLECTION_NAME | quote }}
+  {{- end }}
   EASYOCR_MODULE_PATH: "/tmp/.EasyOCR"
   http_proxy: {{ .Values.global.http_proxy | quote }}
   https_proxy: {{ .Values.global.https_proxy | quote }}

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: retriever-usvc
-              containerPort: 7000
+              containerPort: {{ .Values.port }}
               protocol: TCP
           volumeMounts:
             - mountPath: /tmp

--- a/helm-charts/common/retriever-usvc/templates/service.yaml
+++ b/helm-charts/common/retriever-usvc/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: 7000
+      targetPort: {{ .Values.port }}
       protocol: TCP
       name: retriever-usvc
   selector:

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -7,6 +7,8 @@
 
 tei:
   enabled: false
+milvus:
+  enabled: false
 redis-vector-db:
   enabled: false
 
@@ -17,7 +19,7 @@ replicaCount: 1
 LOGFLAG: ""
 
 TEI_EMBEDDING_ENDPOINT: ""
-EMBED_MODEL: ""
+LOCAL_EMBEDDING_MODEL: ""
 
 REDIS_URL: ""
 INDEX_NAME: "rag-redis"
@@ -48,6 +50,7 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+port: 7000
 service:
   type: ClusterIP
   # The default port for retriever service is 7000
@@ -91,6 +94,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# milvus DB configurations
+MILVUS_HOST: ""
+MILVUS_PORT: ""
+COLLECTION_NAME: ""
+MOSEC_EMBEDDING_ENDPOINT: ""
+MOSEC_EMBEDDING_MODEL: ""
 
 global:
   http_proxy: ""


### PR DESCRIPTION
Add milvus support for data-prep and retriever-usvc.
Use "helm install" with -f milvus-values.yaml
We don't provide milvus deployment helm chart, just reuse the one officially released with current version.
https://artifacthub.io/packages/helm/milvus/milvus

## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

helm install dataprep data-prep -f data-prep/milvus-values.yaml