### PR TITLE
ChatQnA: accelerate also teirerank with Gaudi

### DIFF
--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -1,22 +1,10 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-tei:
-  accelDevice: "gaudi"
-  image:
-    repository: ghcr.io/huggingface/tei-gaudi
-    tag: synapse_1.16
-  resources:
-    limits:
-      habana.ai/gaudi: 1
-  securityContext:
-    readOnlyRootFilesystem: false
-  livenessProbe:
-    timeoutSeconds: 1
-  readinessProbe:
-    timeoutSeconds: 1
+# Accelerate inferencing in heaviest components to improve performance
+# by overriding their subchart values
 
-# To override values in subchart tgi
+# TGI: largest bottleneck for ChatQnA
 tgi:
   accelDevice: "gaudi"
   image:
@@ -41,3 +29,36 @@ tgi:
     periodSeconds: 5
     timeoutSeconds: 1
     failureThreshold: 120
+
+# Reranking: second largest bottleneck when reranking is in use
+# (i.e. query context docs have been uploaded with data-prep)
+teirerank:
+  accelDevice: "gaudi"
+  image:
+    repository: opea/tei-gaudi
+    tag: "1.0"
+  resources:
+    limits:
+      habana.ai/gaudi: 1
+  securityContext:
+    readOnlyRootFilesystem: false
+  livenessProbe:
+    timeoutSeconds: 1
+  readinessProbe:
+    timeoutSeconds: 1
+
+# Embedding: Second largest bottleneck without rerank
+tei:
+  accelDevice: "gaudi"
+  image:
+    repository: ghcr.io/huggingface/tei-gaudi
+    tag: synapse_1.16
+  resources:
+    limits:
+      habana.ai/gaudi: 1
+  securityContext:
+    readOnlyRootFilesystem: false
+  livenessProbe:
+    timeoutSeconds: 1
+  readinessProbe:
+    timeoutSeconds: 1

--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -36,7 +36,7 @@ teirerank:
   accelDevice: "gaudi"
   image:
     repository: opea/tei-gaudi
-    tag: "1.0"
+    tag: "latest"
   resources:
     limits:
       habana.ai/gaudi: 1

--- a/helm-charts/common/teirerank/gaudi-values.yaml
+++ b/helm-charts/common/teirerank/gaudi-values.yaml
@@ -1,0 +1,24 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for teirerank.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+accelDevice: "gaudi"
+
+image:
+  repository: opea/tei-gaudi
+  tag: "1.0"
+
+securityContext:
+  readOnlyRootFilesystem: false
+
+resources:
+  limits:
+    habana.ai/gaudi: 1
+
+livenessProbe:
+  timeoutSeconds: 1
+readinessProbe:
+  timeoutSeconds: 1

--- a/helm-charts/common/teirerank/gaudi-values.yaml
+++ b/helm-charts/common/teirerank/gaudi-values.yaml
@@ -9,7 +9,7 @@ accelDevice: "gaudi"
 
 image:
   repository: opea/tei-gaudi
-  tag: "1.0"
+  tag: "latest"
 
 securityContext:
   readOnlyRootFilesystem: false

--- a/helm-charts/common/teirerank/templates/configmap.yaml
+++ b/helm-charts/common/teirerank/templates/configmap.yaml
@@ -19,3 +19,4 @@ data:
   {{- if .Values.global.HF_ENDPOINT }}
   HF_ENDPOINT: {{ .Values.global.HF_ENDPOINT | quote}}
   {{- end }}
+  MAX_WARMUP_SEQUENCE_LENGTH: "512"


### PR DESCRIPTION
## Description

Accelerate also `teirerank` with Gaudi, not just `tei`.

When reranking is used, it does not make sense (performance-wise) to accelerate just tei, as reranking is a larger bottleneck.

## Issues

#486

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`.

## Tests

Manually checked the ChatQnA throughput.
