### PR TITLE
helm-charts: Add gpt-sovits support

### DIFF
--- a/.github/workflows/pr-chart-validate.yaml
+++ b/.github/workflows/pr-chart-validate.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHARTS_DIR: "helm-charts"
+  CHARTS_DIRS: "helm-charts,helm-charts/common"
 
 jobs:
   charts-validate:
@@ -45,7 +45,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs ${{ env.CHARTS_DIR }} --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --chart-dirs ${{ env.CHARTS_DIRS }} --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -53,4 +53,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm-charts/update_dependency.sh
-          ct lint --check-version-increment=false --validate-maintainers=false --chart-dirs ${{ env.CHARTS_DIR }} --target-branch ${{ github.event.repository.default_branch }}
+          ct lint --check-version-increment=false --validate-maintainers=false --chart-dirs ${{ env.CHARTS_DIRS }} --target-branch ${{ github.event.repository.default_branch }}

--- a/helm-charts/common/gpt-sovits/.helmignore
+++ b/helm-charts/common/gpt-sovits/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/common/gpt-sovits/Chart.yaml
+++ b/helm-charts/common/gpt-sovits/Chart.yaml
@@ -1,0 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: gpt-sovits
+description: The Helm chart for deploying gpt-sovits as microservice
+type: application
+version: 1.1.0
+# The gpt-sovits microservice server version
+appVersion: "1.0"

--- a/helm-charts/common/gpt-sovits/README.md
+++ b/helm-charts/common/gpt-sovits/README.md
@@ -1,0 +1,44 @@
+# gpt-sovits
+
+Helm chart for deploying gpt-sovits microservice.
+
+## Install the chart
+
+```console
+cd GenAIInfra/helm-charts/common/
+helm install gpt-sovits gpt-sovits
+```
+
+## Verify
+
+To verify the installation, run the command `kubectl get pod` to make sure all pods are running.
+
+Then run the command `kubectl port-forward svc/gpt-sovits 9880:9880` to expose the gpt-sovits service for access.
+
+Open another terminal and run the following command to verify the service if working:
+
+- Chinese only
+
+```bash
+curl localhost:9880/ -XPOST -d '{
+    "text": "先帝创业未半而中道崩殂，今天下三分，益州疲弊，此诚危急存亡之秋也。",
+    "text_language": "zh"
+}' --output out.wav
+```
+
+- English only
+
+```bash
+curl localhost:9880/ -XPOST -d '{
+    "text": "Discuss the evolution of text-to-speech (TTS) technology from its early beginnings to the present day. Highlight the advancements in natural language processing that have contributed to more realistic and human-like speech synthesis. Also, explore the various applications of TTS in education, accessibility, and customer service, and predict future trends in this field. Write a comprehensive overview of text-to-speech (TTS) technology.",
+    "text_language": "en"
+}' --output out.wav
+```
+
+## Values
+
+| Key              | Type   | Default             | Description |
+| ---------------- | ------ | ------------------- | ----------- |
+| image.repository | string | `"opea/gpt-sovits"` |             |
+| service.port     | string | `"9880"`            |             |
+| TTS_ENDPOINT     | string | `""`                |             |

--- a/helm-charts/common/gpt-sovits/ci-values.yaml
+++ b/helm-charts/common/gpt-sovits/ci-values.yaml
@@ -1,0 +1,1 @@
+values.yaml

--- a/helm-charts/common/gpt-sovits/templates/_helpers.tpl
+++ b/helm-charts/common/gpt-sovits/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gpt-sovits.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gpt-sovits.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gpt-sovits.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gpt-sovits.labels" -}}
+helm.sh/chart: {{ include "gpt-sovits.chart" . }}
+{{ include "gpt-sovits.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gpt-sovits.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gpt-sovits.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gpt-sovits.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gpt-sovits.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-charts/common/gpt-sovits/templates/configmap.yaml
+++ b/helm-charts/common/gpt-sovits/templates/configmap.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gpt-sovits.fullname" . }}-config
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+data:
+  http_proxy: {{ .Values.global.http_proxy | quote }}
+  https_proxy: {{ .Values.global.https_proxy | quote }}
+  no_proxy: {{ .Values.global.no_proxy | quote }}
+  NUMBA_CACHE_DIR: "/tmp/.cache/numba"
+  HF_HOME: "/tmp/.cache/huggingface"
+  XDG_CACHE_HOME: "/tmp/.cache"

--- a/helm-charts/common/gpt-sovits/templates/deployment.yaml
+++ b/helm-charts/common/gpt-sovits/templates/deployment.yaml
@@ -1,0 +1,92 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gpt-sovits.fullname" . }}
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gpt-sovits.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "gpt-sovits.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Release.Name }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "gpt-sovits.fullname" . }}-config
+            {{- if .Values.global.extraEnvConfig }}
+            - configMapRef:
+                name: {{ .Values.global.extraEnvConfig }}
+                optional: true
+            {{- end }}
+          securityContext:
+            {{- if .Values.global.modelUseHostPath }}
+            {}
+            {{- else }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: gpt-sovits
+              containerPort: 9880
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.evenly_distributed }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "gpt-sovits.selectorLabels" . | nindent 14 }}
+      {{- end }}

--- a/helm-charts/common/gpt-sovits/templates/service.yaml
+++ b/helm-charts/common/gpt-sovits/templates/service.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gpt-sovits.fullname" . }}
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 9880
+      protocol: TCP
+      name: gpt-sovits
+  selector:
+    {{- include "gpt-sovits.selectorLabels" . | nindent 4 }}

--- a/helm-charts/common/gpt-sovits/templates/tests/test-pod.yaml
+++ b/helm-charts/common/gpt-sovits/templates/tests/test-pod.yaml
@@ -1,0 +1,30 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "gpt-sovits.fullname" . }}-testpod"
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    #"helm.sh/hook-delete-policy": "hook-succeeded, hook-failure"
+spec:
+  containers:
+    - name: curl
+      image: python:3.10.14
+      command: ['bash', '-c']
+      args:
+        - |
+          max_retry=20;
+          for ((i=1; i<=max_retry; i++)); do
+            curl -sS --fail-with-body http://{{ include "gpt-sovits.fullname" . }}:{{ .Values.service.port }}/ \
+            -X POST \
+            -d '{"text": "Discuss the evolution of text-to-speech.", "text_language": "en"}' \
+            --output /tmp/out.wav && break;
+            curlcode=$?
+            if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;
+          done;
+          if [ $i -gt $max_retry ]; then echo "test failed with maximum retry"; exit 1; fi
+  restartPolicy: Never

--- a/helm-charts/common/gpt-sovits/values.yaml
+++ b/helm-charts/common/gpt-sovits/values.yaml
@@ -1,0 +1,82 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for whisper.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: opea/gpt-sovits
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  port: 9880
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  tcpSocket:
+    port: gpt-sovits
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 4
+  failureThreshold: 24
+readinessProbe:
+  tcpSocket:
+    port: gpt-sovits
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 4
+startupProbe:
+  tcpSocket:
+    port: gpt-sovits
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 120
+  timeoutSeconds: 2
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  gpt-sovits_proxy: ""
+  gpt-sovitss_proxy: ""
+  no_proxy: ""


### PR DESCRIPTION
## Description

- Add the helm chart for gpt-sovits which is used by AudioQnA multilang example.
- Enable helm lint for GenAIComps charts.

## Issues

#504

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
