### PR TITLE
Add monitoring (ServiceMonitors) for rest of OPEA applications

### DIFF
--- a/helm-charts/audioqna/README.md
+++ b/helm-charts/audioqna/README.md
@@ -53,8 +53,9 @@ curl http://localhost:3008/v1/audioqna \
 
 ## Values
 
-| Key              | Type   | Default                     | Description                                                              |
-| ---------------- | ------ | --------------------------- | ------------------------------------------------------------------------ |
-| image.repository | string | `"opea/audioqna"`           |                                                                          |
-| service.port     | string | `"3008"`                    |                                                                          |
-| tgi.LLM_MODEL_ID | string | `Intel/neural-chat-7b-v3-3` | Models id from https://huggingface.co/, or predownloaded model directory |
+| Key               | Type   | Default                     | Description                                                                            |
+| ----------------- | ------ | --------------------------- | -------------------------------------------------------------------------------------- |
+| image.repository  | string | `"opea/audioqna"`           |                                                                                        |
+| service.port      | string | `"3008"`                    |                                                                                        |
+| tgi.LLM_MODEL_ID  | string | `Intel/neural-chat-7b-v3-3` | Models id from https://huggingface.co/, or predownloaded model directory               |
+| global.monitoring | bool   | `false`                     | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/audioqna/templates/servicemonitor.yaml
+++ b/helm-charts/audioqna/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "audioqna.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "audioqna.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: audioqna
+    interval: 5s
+{{- end }}

--- a/helm-charts/audioqna/values.yaml
+++ b/helm-charts/audioqna/values.yaml
@@ -60,3 +60,9 @@ global:
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models
   # modelUsePVC: model-volume
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -56,8 +56,9 @@ Open a browser to access `http://<k8s-node-ip-address>:${port}` to play with the
 
 ## Values
 
-| Key              | Type   | Default                            | Description                                                              |
-| ---------------- | ------ | ---------------------------------- | ------------------------------------------------------------------------ |
-| image.repository | string | `"opea/codegen"`                   |                                                                          |
-| service.port     | string | `"7778"`                           |                                                                          |
-| tgi.LLM_MODEL_ID | string | `"Qwen/Qwen2.5-Coder-7B-Instruct"` | Models id from https://huggingface.co/, or predownloaded model directory |
+| Key               | Type   | Default                            | Description                                                                            |
+| ----------------- | ------ | ---------------------------------- | -------------------------------------------------------------------------------------- |
+| image.repository  | string | `"opea/codegen"`                   |                                                                                        |
+| service.port      | string | `"7778"`                           |                                                                                        |
+| tgi.LLM_MODEL_ID  | string | `"Qwen/Qwen2.5-Coder-7B-Instruct"` | Models id from https://huggingface.co/, or predownloaded model directory               |
+| global.monitoring | bool   | `false`                            | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/codegen/templates/servicemonitor.yaml
+++ b/helm-charts/codegen/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "codegen.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "codegen.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: codegen
+    interval: 5s
+{{- end }}

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -59,3 +59,9 @@ global:
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models
   # modelUsePVC: model-volume
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/codetrans/README.md
+++ b/helm-charts/codetrans/README.md
@@ -57,8 +57,9 @@ Open a browser to access `http://<k8s-node-ip-address>:${port}` to play with the
 
 ## Values
 
-| Key              | Type   | Default                                | Description                                                              |
-| ---------------- | ------ | -------------------------------------- | ------------------------------------------------------------------------ |
-| image.repository | string | `"opea/codetrans"`                     |                                                                          |
-| service.port     | string | `"7777"`                               |                                                                          |
-| tgi.LLM_MODEL_ID | string | `"mistralai/Mistral-7B-Instruct-v0.3"` | Models id from https://huggingface.co/, or predownloaded model directory |
+| Key               | Type   | Default                                | Description                                                                            |
+| ----------------- | ------ | -------------------------------------- | -------------------------------------------------------------------------------------- |
+| image.repository  | string | `"opea/codetrans"`                     |                                                                                        |
+| service.port      | string | `"7777"`                               |                                                                                        |
+| tgi.LLM_MODEL_ID  | string | `"mistralai/Mistral-7B-Instruct-v0.3"` | Models id from https://huggingface.co/, or predownloaded model directory               |
+| global.monitoring | bool   | `false`                                | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/codetrans/templates/servicemonitor.yaml
+++ b/helm-charts/codetrans/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "codetrans.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "codetrans.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: codetrans
+    interval: 5s
+{{- end }}

--- a/helm-charts/codetrans/values.yaml
+++ b/helm-charts/codetrans/values.yaml
@@ -60,3 +60,9 @@ global:
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models
   # modelUsePVC: model-volume
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/docsum/README.md
+++ b/helm-charts/docsum/README.md
@@ -51,8 +51,9 @@ Open a browser to access `http://<k8s-node-ip-address>:${port}` to play with the
 
 ## Values
 
-| Key              | Type   | Default                       | Description                                                              |
-| ---------------- | ------ | ----------------------------- | ------------------------------------------------------------------------ |
-| image.repository | string | `"opea/docsum"`               |                                                                          |
-| service.port     | string | `"8888"`                      |                                                                          |
-| tgi.LLM_MODEL_ID | string | `"Intel/neural-chat-7b-v3-3"` | Models id from https://huggingface.co/, or predownloaded model directory |
+| Key               | Type   | Default                       | Description                                                                            |
+| ----------------- | ------ | ----------------------------- | -------------------------------------------------------------------------------------- |
+| image.repository  | string | `"opea/docsum"`               |                                                                                        |
+| service.port      | string | `"8888"`                      |                                                                                        |
+| tgi.LLM_MODEL_ID  | string | `"Intel/neural-chat-7b-v3-3"` | Models id from https://huggingface.co/, or predownloaded model directory               |
+| global.monitoring | bool   | `false`                       | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/docsum/templates/servicemonitor.yaml
+++ b/helm-charts/docsum/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "docsum.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "docsum.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: docsum
+    interval: 5s
+{{- end }}

--- a/helm-charts/docsum/values.yaml
+++ b/helm-charts/docsum/values.yaml
@@ -65,3 +65,9 @@ global:
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models
   # modelUsePVC: model-volume
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/faqgen/README.md
+++ b/helm-charts/faqgen/README.md
@@ -35,8 +35,9 @@ Open a browser to access `http://<k8s-node-ip-address>:${port}` to play with the
 
 ## Values
 
-| Key              | Type   | Default                                 | Description                                                              |
-| ---------------- | ------ | --------------------------------------- | ------------------------------------------------------------------------ |
-| image.repository | string | `"opea/faqgen"`                         |                                                                          |
-| service.port     | string | `"8888"`                                |                                                                          |
-| tgi.LLM_MODEL_ID | string | `"meta-llama/Meta-Llama-3-8B-Instruct"` | Models id from https://huggingface.co/, or predownloaded model directory |
+| Key               | Type   | Default                                 | Description                                                                            |
+| ----------------- | ------ | --------------------------------------- | -------------------------------------------------------------------------------------- |
+| image.repository  | string | `"opea/faqgen"`                         |                                                                                        |
+| service.port      | string | `"8888"`                                |                                                                                        |
+| tgi.LLM_MODEL_ID  | string | `"meta-llama/Meta-Llama-3-8B-Instruct"` | Models id from https://huggingface.co/, or predownloaded model directory               |
+| global.monitoring | bool   | `false`                                 | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/faqgen/templates/servicemonitor.yaml
+++ b/helm-charts/faqgen/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "faqgen.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "faqgen.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: faqgen
+    interval: 5s
+{{- end }}

--- a/helm-charts/faqgen/values.yaml
+++ b/helm-charts/faqgen/values.yaml
@@ -64,3 +64,9 @@ global:
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models
   # modelUsePVC: model-volume
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/visualqna/README.md
+++ b/helm-charts/visualqna/README.md
@@ -42,4 +42,4 @@ Open a browser to access `http://<k8s-node-ip-address>:${port}` to play with the
 | image.repository  | string | `"opea/visualqna"`                    |                                                                                        |
 | service.port      | string | `"8888"`                              |                                                                                        |
 | tgi.LLM_MODEL_ID  | string | `"llava-hf/llava-v1.6-mistral-7b-hf"` | Models id from https://huggingface.co/, or predownloaded model directory               |
-| global.monitoring | bop;   | false                                 | Enable usage metrics for the service components. See ../monitoring.md before enabling! |
+| global.monitoring | bool   | `false`                               | Enable usage metrics for the service components. See ../monitoring.md before enabling! |

--- a/helm-charts/visualqna/templates/servicemonitor.yaml
+++ b/helm-charts/visualqna/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "visualqna.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "visualqna.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: visualqna
+    interval: 5s
+{{- end }}


### PR DESCRIPTION
## Description

Background: All applications already use Gateway => HttpService class instance, so they all already provide Prometheus metrics end point.   And https://github.com/opea-project/GenAIComps/pull/845 adds more service specific Prometheus metrics to ServiceOrchestrator, which is also used by the all the applications.

This PR adds `ServiceMonitor`s to all the remaining applications, so that their metrics are also visible in Prometheus, Grafana etc, similarly to ChatQnA (PR #488).

This includes fix to VisualQnA, which README and values file incorrectly contained the monitoring items, but had no ServiceMonitor.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

`n/a`. 

## Tests

Manually verified that rest of the applications `Service` files are identical to ChatQnA except for the service name, and that their values files have a global section at end.  Therefore I could automate adding `ServiceMonitor` objects to them, and Helm options to their `values.html` file.