### PR TITLE
Limit max_tokens to save test time

### DIFF
--- a/helm-charts/common/llm-uservice/templates/tests/test-pod.yaml
+++ b/helm-charts/common/llm-uservice/templates/tests/test-pod.yaml
@@ -23,13 +23,13 @@ spec:
           # Try with docsum endpoint
             curl http://{{ include "llm-uservice.fullname" . }}:{{ .Values.service.port }}/v1/chat/docsum -sS --fail-with-body \
               -X POST \
-              -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5."}' \
+              -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens":17}' \
               -H 'Content-Type: application/json' && break;
           {{- else if contains "llm-faqgen-tgi" .Values.image.repository }}
           # Try with faqgen endpoint
             curl http://{{ include "llm-uservice.fullname" . }}:{{ .Values.service.port }}/v1/faqgen -sS --fail-with-body \
               -X POST \
-              -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5."}' \
+              -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens":17}' \
               -H 'Content-Type: application/json' && break;
           {{- else }}
             curl http://{{ include "llm-uservice.fullname" . }}:{{ .Values.service.port }}/v1/chat/completions -sS --fail-with-body \

--- a/helm-charts/faqgen/templates/tests/test-pod.yaml
+++ b/helm-charts/faqgen/templates/tests/test-pod.yaml
@@ -21,7 +21,7 @@ spec:
           for ((i=1; i<=max_retry; i++)); do
             curl http://{{ include "faqgen.fullname" . }}:{{ .Values.service.port }}/v1/faqgen -sS --fail-with-body \
             -H "Content-Type: application/json" \
-            -d '{"messages": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5."}' && break;
+            -d '{"messages": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens":17}' && break;
             curlcode=$?
             if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;
           done;


### PR DESCRIPTION
## Description

Limit max_tokens to 17 save test time and avoid sporadic timout on busy CI nodes on cpu case.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Dependencies

n/a.

## Tests

CI.
