### PR TITLE
Fix: TGI Gaudi limits need to be higher with for ChatQnA / when rerank is used

### DIFF
--- a/helm-charts/chatqna/gaudi-values.yaml
+++ b/helm-charts/chatqna/gaudi-values.yaml
@@ -13,8 +13,8 @@ tgi:
   resources:
     limits:
       habana.ai/gaudi: 1
-  MAX_INPUT_LENGTH: "1024"
-  MAX_TOTAL_TOKENS: "2048"
+  MAX_INPUT_LENGTH: "2048"
+  MAX_TOTAL_TOKENS: "4096"
   CUDA_GRAPHS: ""
   livenessProbe:
     initialDelaySeconds: 5

--- a/helm-charts/chatqna/guardrails-gaudi-values.yaml
+++ b/helm-charts/chatqna/guardrails-gaudi-values.yaml
@@ -50,8 +50,8 @@ tgi:
   resources:
     limits:
       habana.ai/gaudi: 1
-  MAX_INPUT_LENGTH: "1024"
-  MAX_TOTAL_TOKENS: "2048"
+  MAX_INPUT_LENGTH: "2048"
+  MAX_TOTAL_TOKENS: "4096"
   CUDA_GRAPHS: ""
   livenessProbe:
     initialDelaySeconds: 5
@@ -76,8 +76,8 @@ tgi-guardrails:
   resources:
     limits:
       habana.ai/gaudi: 1
-  MAX_INPUT_LENGTH: "1024"
-  MAX_TOTAL_TOKENS: "2048"
+  MAX_INPUT_LENGTH: "2048"
+  MAX_TOTAL_TOKENS: "4096"
   CUDA_GRAPHS: ""
   livenessProbe:
     initialDelaySeconds: 5


### PR DESCRIPTION
## Description

Use of reranking adds large number of tokens to the input. Limits for TGI Gaudi version are so low that it will fail, unless limits are significantly increased.

This doubles the limits, but only for ChatQnA, as it's currently only application (optionally) using reranking.

## Issues

Fixes: https://github.com/opea-project/GenAIInfra/issues/487

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`.

## Tests

I've manually tested that  without this change, Gaudi TGI fails when reranking is used, but works with it.

## Questions

Why CI did not catch this issue; does not it use rerank, or verify that document data-prepping worked?