### PR TITLE
Update versions in Helm charts and GMC manifests to v1.1

### DIFF
--- a/helm-charts/agentqna/Chart.yaml
+++ b/helm-charts/agentqna/Chart.yaml
@@ -7,37 +7,37 @@ description: The Helm chart to deploy AgentQnA
 type: application
 dependencies:
   - name: agent
-    version: 1.0.0
+    version: 1.1.0
     alias: worker
     repository: "file://../common/agent"
   - name: agent
-    version: 1.0.0
+    version: 1.1.0
     alias: supervisor
     repository: "file://../common/agent"
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
     condition: tgi.enabled
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tei"
   - name: embedding-usvc
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/embedding-usvc"
   - name: teirerank
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/teirerank"
   - name: reranking-usvc
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/reranking-usvc"
   - name: redis-vector-db
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/redis-vector-db"
   - name: retriever-usvc
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/retriever-usvc"
   - name: data-prep
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/data-prep"
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/audioqna/Chart.yaml
+++ b/helm-charts/audioqna/Chart.yaml
@@ -7,27 +7,27 @@ description: The Helm chart to deploy AudioQnA
 type: application
 dependencies:
   - name: asr
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/asr"
   - name: whisper
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/whisper"
   - name: tts
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tts"
   - name: speecht5
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/speecht5"
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/llm-uservice"
 # Uncomment the following to enable UI when the UI image is ready on DockerHub
 # - name: ui
-#  version: 1.0.0
+#  version: 1.1.0
 #  repository: "file://../common/ui"
 #  alias: audioqna-ui
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.1"

--- a/helm-charts/chatqna/Chart.yaml
+++ b/helm-charts/chatqna/Chart.yaml
@@ -7,35 +7,35 @@ description: The Helm chart to deploy ChatQnA
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     alias: tgi-guardrails
     repository: "file://../common/tgi"
     condition: guardrails-usvc.enabled
   - name: guardrails-usvc
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/guardrails-usvc"
     condition: guardrails-usvc.enabled
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tei"
   - name: teirerank
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/teirerank"
   - name: redis-vector-db
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/redis-vector-db"
   - name: retriever-usvc
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/retriever-usvc"
   - name: data-prep
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/data-prep"
   - name: ui
     alias: chatqna-ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/codegen/Chart.yaml
+++ b/helm-charts/codegen/Chart.yaml
@@ -7,14 +7,14 @@ description: The Helm chart to deploy CodeGen
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/llm-uservice"
   - name: ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
     alias: codegen-ui
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/codetrans/Chart.yaml
+++ b/helm-charts/codetrans/Chart.yaml
@@ -7,14 +7,14 @@ description: The Helm chart to deploy CodeTrans
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/llm-uservice"
   - name: ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
     alias: codetrans-ui
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/common/agent/Chart.yaml
+++ b/helm-charts/common/agent/Chart.yaml
@@ -5,15 +5,15 @@ apiVersion: v2
 name: agent
 description: The Helm chart for deploying agent microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The llm microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tgi
     condition: tgi.enabled
   - name: vllm
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../vllm
     condition: vllm.enabled

--- a/helm-charts/common/asr/Chart.yaml
+++ b/helm-charts/common/asr/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: asr
 description: The Helm chart for deploying asr as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The asr microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: whisper
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../whisper
     condition: whisper.enabled

--- a/helm-charts/common/chathistory-usvc/Chart.yaml
+++ b/helm-charts/common/chathistory-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: chathistory-usvc
 description: The Helm chart for deploying chat history as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The chat history microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: mongodb
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../mongodb
     condition: mongodb.enabled

--- a/helm-charts/common/data-prep/Chart.yaml
+++ b/helm-charts/common/data-prep/Chart.yaml
@@ -5,16 +5,16 @@ apiVersion: v2
 name: data-prep
 description: The Helm chart for deploying data prep as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The data prep microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tei
     condition: tei.enabled
   - name: redis-vector-db
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../redis-vector-db
     condition: redis-vector-db.enabled
   - name: milvus

--- a/helm-charts/common/embedding-usvc/Chart.yaml
+++ b/helm-charts/common/embedding-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: embedding-usvc
 description: The Helm chart for deploying embedding as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The embedding microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tei
     condition: tei.enabled

--- a/helm-charts/common/gpt-sovits/Chart.yaml
+++ b/helm-charts/common/gpt-sovits/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: gpt-sovits
 description: The Helm chart for deploying gpt-sovits as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The gpt-sovits microservice server version
 appVersion: "1.0"

--- a/helm-charts/common/guardrails-usvc/Chart.yaml
+++ b/helm-charts/common/guardrails-usvc/Chart.yaml
@@ -5,10 +5,10 @@ apiVersion: v2
 name: guardrails-usvc
 description: The Helm chart for deploying guardrails-usvc as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tgi
     condition: tgi.enabled

--- a/helm-charts/common/llm-uservice/Chart.yaml
+++ b/helm-charts/common/llm-uservice/Chart.yaml
@@ -5,15 +5,15 @@ apiVersion: v2
 name: llm-uservice
 description: The Helm chart for deploying llm as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The llm microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tgi
     condition: tgi.enabled
   - name: vllm
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../vllm
     condition: vllm.enabled

--- a/helm-charts/common/lvm-uservice/Chart.yaml
+++ b/helm-charts/common/lvm-uservice/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: lvm-uservice
 description: The Helm chart for deploying lvm as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The lvm microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tgi
     condition: tgi.enabled

--- a/helm-charts/common/mongodb/Chart.yaml
+++ b/helm-charts/common/mongodb/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: mongodb
 description: The Helm chart for Redis Vector DB
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "7.0.11"

--- a/helm-charts/common/prompt-usvc/Chart.yaml
+++ b/helm-charts/common/prompt-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: prompt-usvc
 description: The Helm chart for deploying prompt as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The prompt microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: mongodb
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../mongodb
     condition: mongodb.enabled

--- a/helm-charts/common/redis-vector-db/Chart.yaml
+++ b/helm-charts/common/redis-vector-db/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: redis-vector-db
 description: The Helm chart for Redis Vector DB
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "7.2.0-v9"

--- a/helm-charts/common/reranking-usvc/Chart.yaml
+++ b/helm-charts/common/reranking-usvc/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: reranking-usvc
 description: The Helm chart for deploying reranking as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The reranking microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: teirerank
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../teirerank
     condition: teirerank.enabled

--- a/helm-charts/common/retriever-usvc/Chart.yaml
+++ b/helm-charts/common/retriever-usvc/Chart.yaml
@@ -5,16 +5,16 @@ apiVersion: v2
 name: retriever-usvc
 description: The Helm chart for deploying retriever as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The retriever microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tei
     condition: tei.enabled
   - name: redis-vector-db
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../redis-vector-db
     condition: redis-vector-db.enabled
   - name: milvus

--- a/helm-charts/common/speecht5/Chart.yaml
+++ b/helm-charts/common/speecht5/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: speecht5
 description: The Helm chart for deploying speecht5 as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The speecht5 microservice server version
 appVersion: "v1.0"

--- a/helm-charts/common/tei/Chart.yaml
+++ b/helm-charts/common/tei/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tei
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 1.0.0
+version: 1.1.0
 # The HF TEI version
 appVersion: "cpu-1.5"

--- a/helm-charts/common/teirerank/Chart.yaml
+++ b/helm-charts/common/teirerank/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: teirerank
 description: The Helm chart for HuggingFace Text Embedding Inference Server
 type: application
-version: 1.0.0
+version: 1.1.0
 # The HF TEI version
 appVersion: "cpu-1.5"

--- a/helm-charts/common/tgi/Chart.yaml
+++ b/helm-charts/common/tgi/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: tgi
 description: The Helm chart for HuggingFace Text Generation Inference Server
 type: application
-version: 1.0.0
+version: 1.1.0
 # The HF TGI version
 appVersion: "2.1.0"

--- a/helm-charts/common/tts/Chart.yaml
+++ b/helm-charts/common/tts/Chart.yaml
@@ -5,12 +5,12 @@ apiVersion: v2
 name: tts
 description: The Helm chart for deploying tts as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The tts microservice server version
 appVersion: "v1.0"
 
 dependencies:
   - name: speecht5
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../speecht5
     condition: speecht5.enabled

--- a/helm-charts/common/ui/Chart.yaml
+++ b/helm-charts/common/ui/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: ui
 description: Common Helm chart for the UI for various opea workload
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/common/vllm/Chart.yaml
+++ b/helm-charts/common/vllm/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: vllm
 description: The Helm chart for vLLM Inference Server
 type: application
-version: 1.0.0
+version: 1.1.0
 # The vLLM version
 appVersion: "0.5"

--- a/helm-charts/common/web-retriever/Chart.yaml
+++ b/helm-charts/common/web-retriever/Chart.yaml
@@ -5,11 +5,11 @@ apiVersion: v2
 name: web-retriever
 description: The Helm chart for deploying web retriever as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The web retriever microservice server version
 appVersion: "v1.0"
 dependencies:
   - name: tei
-    version: 1.0.0
+    version: 1.1.0
     repository: file://../tei
     condition: tei.enabled

--- a/helm-charts/common/whisper/Chart.yaml
+++ b/helm-charts/common/whisper/Chart.yaml
@@ -5,6 +5,6 @@ apiVersion: v2
 name: whisper
 description: The Helm chart for deploying whisper as microservice
 type: application
-version: 1.0.0
+version: 1.1.0
 # The whisper microservice server version
 appVersion: "v1.0"

--- a/helm-charts/docsum/Chart.yaml
+++ b/helm-charts/docsum/Chart.yaml
@@ -7,17 +7,17 @@ description: The Helm chart to deploy DocSum
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/llm-uservice"
   - name: whisper
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/whisper"
   - name: ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
     alias: docsum-ui
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/faqgen/Chart.yaml
+++ b/helm-charts/faqgen/Chart.yaml
@@ -7,14 +7,14 @@ description: The Helm chart to deploy FaqGen
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: llm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/llm-uservice"
   - name: ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
     alias: faqgen-ui
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/helm-charts/visualqna/Chart.yaml
+++ b/helm-charts/visualqna/Chart.yaml
@@ -7,14 +7,14 @@ description: The Helm chart to deploy VisualQnA
 type: application
 dependencies:
   - name: tgi
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/tgi"
   - name: lvm-uservice
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/lvm-uservice"
   - name: ui
     alias: visualqna-ui
-    version: 1.0.0
+    version: 1.1.0
     repository: "file://../common/ui"
-version: 1.0.0
+version: 1.1.0
 appVersion: "v1.0"

--- a/microservices-connector/config/manifests/agent.yaml
+++ b/microservices-connector/config/manifests/agent.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: agent-config
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"
@@ -41,7 +41,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"
@@ -66,7 +66,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/agent_gaudi.yaml
+++ b/microservices-connector/config/manifests/agent_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: agent-tgi-config
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "2.1.0"
@@ -44,7 +44,7 @@ kind: ConfigMap
 metadata:
   name: agent-config
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: agent-tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "2.1.0"
@@ -102,7 +102,7 @@ kind: Service
 metadata:
   name: agent
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"
@@ -127,7 +127,7 @@ kind: Deployment
 metadata:
   name: agent-tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "2.1.0"
@@ -217,7 +217,7 @@ kind: Deployment
 metadata:
   name: agent
   labels:
-    helm.sh/chart: agent-1.0.0
+    helm.sh/chart: agent-1.1.0
     app.kubernetes.io/name: agent
     app.kubernetes.io/instance: agent
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/asr.yaml
+++ b/microservices-connector/config/manifests/asr.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: asr-config
   labels:
-    helm.sh/chart: asr-1.0.0
+    helm.sh/chart: asr-1.1.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
     app.kubernetes.io/version: "v1.0"
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: asr
   labels:
-    helm.sh/chart: asr-1.0.0
+    helm.sh/chart: asr-1.1.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
     app.kubernetes.io/version: "v1.0"
@@ -54,7 +54,7 @@ kind: Deployment
 metadata:
   name: asr
   labels:
-    helm.sh/chart: asr-1.0.0
+    helm.sh/chart: asr-1.1.0
     app.kubernetes.io/name: asr
     app.kubernetes.io/instance: asr
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/chathistory-usvc.yaml
+++ b/microservices-connector/config/manifests/chathistory-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: chathistory-usvc-config
   labels:
-    helm.sh/chart: chathistory-usvc-1.0.0
+    helm.sh/chart: chathistory-usvc-1.1.0
     app.kubernetes.io/name: chathistory-usvc
     app.kubernetes.io/instance: chathistory-usvc
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: chathistory-usvc
   labels:
-    helm.sh/chart: chathistory-usvc-1.0.0
+    helm.sh/chart: chathistory-usvc-1.1.0
     app.kubernetes.io/name: chathistory-usvc
     app.kubernetes.io/instance: chathistory-usvc
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: chathistory-usvc
   labels:
-    helm.sh/chart: chathistory-usvc-1.0.0
+    helm.sh/chart: chathistory-usvc-1.1.0
     app.kubernetes.io/name: chathistory-usvc
     app.kubernetes.io/instance: chathistory-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/chatqna_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/chatqna_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: chatqna-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: chatqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -28,7 +28,7 @@ kind: Service
 metadata:
   name: chatqna-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: chatqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -53,7 +53,7 @@ kind: Deployment
 metadata:
   name: chatqna-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: chatqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -67,7 +67,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: chatqna-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/codegen_react-ui.yaml
+++ b/microservices-connector/config/manifests/codegen_react-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: codegen-react-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: codegen-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: codegen-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: codegen-react-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/codegen_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/codegen_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: codegen-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: codegen-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: codegen-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codegen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: codegen-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/codetrans_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/codetrans_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: codetrans-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codetrans-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: codetrans-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codetrans-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: codetrans-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: codetrans-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: codetrans-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/data-prep.yaml
+++ b/microservices-connector/config/manifests/data-prep.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: data-prep-config
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"
@@ -38,7 +38,7 @@ kind: Service
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"
@@ -63,7 +63,7 @@ kind: Deployment
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/data-prep_milvus.yaml
+++ b/microservices-connector/config/manifests/data-prep_milvus.yaml
@@ -241,7 +241,7 @@ kind: ConfigMap
 metadata:
   name: data-prep-tei-config
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "cpu-1.5"
@@ -268,7 +268,7 @@ kind: ConfigMap
 metadata:
   name: data-prep-config
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"
@@ -444,7 +444,7 @@ kind: Service
 metadata:
   name: data-prep-tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "cpu-1.5"
@@ -469,7 +469,7 @@ kind: Service
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"
@@ -692,7 +692,7 @@ kind: Deployment
 metadata:
   name: data-prep-tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "cpu-1.5"
@@ -782,7 +782,7 @@ kind: Deployment
 metadata:
   name: data-prep
   labels:
-    helm.sh/chart: data-prep-1.0.0
+    helm.sh/chart: data-prep-1.1.0
     app.kubernetes.io/name: data-prep
     app.kubernetes.io/instance: data-prep
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/docsum-llm-uservice.yaml
+++ b/microservices-connector/config/manifests/docsum-llm-uservice.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: docsum-llm-uservice-config
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum-llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: docsum-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum-llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: docsum-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: docsum-llm-uservice
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/docsum_react-ui.yaml
+++ b/microservices-connector/config/manifests/docsum_react-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: docsum-react-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: docsum-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: docsum-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: docsum-react-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/docsum_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/docsum_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: docsum-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -26,7 +26,7 @@ kind: Service
 metadata:
   name: docsum-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -51,7 +51,7 @@ kind: Deployment
 metadata:
   name: docsum-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: docsum-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -65,7 +65,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: docsum-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/embedding-usvc.yaml
+++ b/microservices-connector/config/manifests/embedding-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: embedding-usvc-config
   labels:
-    helm.sh/chart: embedding-usvc-1.0.0
+    helm.sh/chart: embedding-usvc-1.1.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
     app.kubernetes.io/version: "v1.0"
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: embedding-usvc
   labels:
-    helm.sh/chart: embedding-usvc-1.0.0
+    helm.sh/chart: embedding-usvc-1.1.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
     app.kubernetes.io/version: "v1.0"
@@ -54,7 +54,7 @@ kind: Deployment
 metadata:
   name: embedding-usvc
   labels:
-    helm.sh/chart: embedding-usvc-1.0.0
+    helm.sh/chart: embedding-usvc-1.1.0
     app.kubernetes.io/name: embedding-usvc
     app.kubernetes.io/instance: embedding-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/faqgen-llm-uservice.yaml
+++ b/microservices-connector/config/manifests/faqgen-llm-uservice.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: faqgen-llm-uservice-config
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: faqgen-llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: faqgen-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: faqgen-llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: faqgen-llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: faqgen-llm-uservice
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/faqgen_react-ui.yaml
+++ b/microservices-connector/config/manifests/faqgen_react-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: faqgen-react-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: faqgen-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: faqgen-react-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-react-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: faqgen-react-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/faqgen_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/faqgen_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: faqgen-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: faqgen-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: faqgen-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: faqgen-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: faqgen-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/gpt-sovits.yaml
+++ b/microservices-connector/config/manifests/gpt-sovits.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: gpt-sovits-config
   labels:
-    helm.sh/chart: gpt-sovits-1.0.0
+    helm.sh/chart: gpt-sovits-1.1.0
     app.kubernetes.io/name: gpt-sovits
     app.kubernetes.io/instance: gpt-sovits
     app.kubernetes.io/version: "1.0"
@@ -30,7 +30,7 @@ kind: Service
 metadata:
   name: gpt-sovits
   labels:
-    helm.sh/chart: gpt-sovits-1.0.0
+    helm.sh/chart: gpt-sovits-1.1.0
     app.kubernetes.io/name: gpt-sovits
     app.kubernetes.io/instance: gpt-sovits
     app.kubernetes.io/version: "1.0"
@@ -55,7 +55,7 @@ kind: Deployment
 metadata:
   name: gpt-sovits
   labels:
-    helm.sh/chart: gpt-sovits-1.0.0
+    helm.sh/chart: gpt-sovits-1.1.0
     app.kubernetes.io/name: gpt-sovits
     app.kubernetes.io/instance: gpt-sovits
     app.kubernetes.io/version: "1.0"

--- a/microservices-connector/config/manifests/guardrails-usvc.yaml
+++ b/microservices-connector/config/manifests/guardrails-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: guardrails-usvc-config
   labels:
-    helm.sh/chart: guardrails-usvc-1.0.0
+    helm.sh/chart: guardrails-usvc-1.1.0
     app.kubernetes.io/name: guardrails-usvc
     app.kubernetes.io/instance: guardrails-usvc
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: guardrails-usvc
   labels:
-    helm.sh/chart: guardrails-usvc-1.0.0
+    helm.sh/chart: guardrails-usvc-1.1.0
     app.kubernetes.io/name: guardrails-usvc
     app.kubernetes.io/instance: guardrails-usvc
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: guardrails-usvc
   labels:
-    helm.sh/chart: guardrails-usvc-1.0.0
+    helm.sh/chart: guardrails-usvc-1.1.0
     app.kubernetes.io/name: guardrails-usvc
     app.kubernetes.io/instance: guardrails-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/llm-uservice.yaml
+++ b/microservices-connector/config/manifests/llm-uservice.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: llm-uservice-config
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: llm-uservice
   labels:
-    helm.sh/chart: llm-uservice-1.0.0
+    helm.sh/chart: llm-uservice-1.1.0
     app.kubernetes.io/name: llm-uservice
     app.kubernetes.io/instance: llm-uservice
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/lvm-uservice.yaml
+++ b/microservices-connector/config/manifests/lvm-uservice.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: lvm-uservice-config
   labels:
-    helm.sh/chart: lvm-uservice-1.0.0
+    helm.sh/chart: lvm-uservice-1.1.0
     app.kubernetes.io/name: lvm-uservice
     app.kubernetes.io/instance: lvm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -31,7 +31,7 @@ kind: Service
 metadata:
   name: lvm-uservice
   labels:
-    helm.sh/chart: lvm-uservice-1.0.0
+    helm.sh/chart: lvm-uservice-1.1.0
     app.kubernetes.io/name: lvm-uservice
     app.kubernetes.io/instance: lvm-uservice
     app.kubernetes.io/version: "v1.0"
@@ -56,7 +56,7 @@ kind: Deployment
 metadata:
   name: lvm-uservice
   labels:
-    helm.sh/chart: lvm-uservice-1.0.0
+    helm.sh/chart: lvm-uservice-1.1.0
     app.kubernetes.io/name: lvm-uservice
     app.kubernetes.io/instance: lvm-uservice
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/mongodb.yaml
+++ b/microservices-connector/config/manifests/mongodb.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: mongodb
   labels:
-    helm.sh/chart: mongodb-1.0.0
+    helm.sh/chart: mongodb-1.1.0
     app.kubernetes.io/name: mongodb
     app.kubernetes.io/instance: mongodb
     app.kubernetes.io/version: "7.0.11"
@@ -33,7 +33,7 @@ kind: Deployment
 metadata:
   name: mongodb
   labels:
-    helm.sh/chart: mongodb-1.0.0
+    helm.sh/chart: mongodb-1.1.0
     app.kubernetes.io/name: mongodb
     app.kubernetes.io/instance: mongodb
     app.kubernetes.io/version: "7.0.11"

--- a/microservices-connector/config/manifests/prompt-usvc.yaml
+++ b/microservices-connector/config/manifests/prompt-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: prompt-usvc-config
   labels:
-    helm.sh/chart: prompt-usvc-1.0.0
+    helm.sh/chart: prompt-usvc-1.1.0
     app.kubernetes.io/name: prompt-usvc
     app.kubernetes.io/instance: prompt-usvc
     app.kubernetes.io/version: "v1.0"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: prompt-usvc
   labels:
-    helm.sh/chart: prompt-usvc-1.0.0
+    helm.sh/chart: prompt-usvc-1.1.0
     app.kubernetes.io/name: prompt-usvc
     app.kubernetes.io/instance: prompt-usvc
     app.kubernetes.io/version: "v1.0"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: prompt-usvc
   labels:
-    helm.sh/chart: prompt-usvc-1.0.0
+    helm.sh/chart: prompt-usvc-1.1.0
     app.kubernetes.io/name: prompt-usvc
     app.kubernetes.io/instance: prompt-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/redis-vector-db.yaml
+++ b/microservices-connector/config/manifests/redis-vector-db.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: redis-vector-db
   labels:
-    helm.sh/chart: redis-vector-db-1.0.0
+    helm.sh/chart: redis-vector-db-1.1.0
     app.kubernetes.io/name: redis-vector-db
     app.kubernetes.io/instance: redis-vector-db
     app.kubernetes.io/version: "7.2.0-v9"
@@ -37,7 +37,7 @@ kind: Deployment
 metadata:
   name: redis-vector-db
   labels:
-    helm.sh/chart: redis-vector-db-1.0.0
+    helm.sh/chart: redis-vector-db-1.1.0
     app.kubernetes.io/name: redis-vector-db
     app.kubernetes.io/instance: redis-vector-db
     app.kubernetes.io/version: "7.2.0-v9"

--- a/microservices-connector/config/manifests/reranking-usvc.yaml
+++ b/microservices-connector/config/manifests/reranking-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: reranking-usvc-config
   labels:
-    helm.sh/chart: reranking-usvc-1.0.0
+    helm.sh/chart: reranking-usvc-1.1.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
     app.kubernetes.io/version: "v1.0"
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: reranking-usvc
   labels:
-    helm.sh/chart: reranking-usvc-1.0.0
+    helm.sh/chart: reranking-usvc-1.1.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
     app.kubernetes.io/version: "v1.0"
@@ -54,7 +54,7 @@ kind: Deployment
 metadata:
   name: reranking-usvc
   labels:
-    helm.sh/chart: reranking-usvc-1.0.0
+    helm.sh/chart: reranking-usvc-1.1.0
     app.kubernetes.io/name: reranking-usvc
     app.kubernetes.io/instance: reranking-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/retriever-usvc.yaml
+++ b/microservices-connector/config/manifests/retriever-usvc.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: retriever-usvc-config
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"
@@ -37,7 +37,7 @@ kind: Service
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"
@@ -62,7 +62,7 @@ kind: Deployment
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/retriever-usvc_milvus.yaml
+++ b/microservices-connector/config/manifests/retriever-usvc_milvus.yaml
@@ -241,7 +241,7 @@ kind: ConfigMap
 metadata:
   name: retriever-usvc-tei-config
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "cpu-1.5"
@@ -268,7 +268,7 @@ kind: ConfigMap
 metadata:
   name: retriever-usvc-config
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"
@@ -443,7 +443,7 @@ kind: Service
 metadata:
   name: retriever-usvc-tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "cpu-1.5"
@@ -468,7 +468,7 @@ kind: Service
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"
@@ -691,7 +691,7 @@ kind: Deployment
 metadata:
   name: retriever-usvc-tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "cpu-1.5"
@@ -781,7 +781,7 @@ kind: Deployment
 metadata:
   name: retriever-usvc
   labels:
-    helm.sh/chart: retriever-usvc-1.0.0
+    helm.sh/chart: retriever-usvc-1.1.0
     app.kubernetes.io/name: retriever-usvc
     app.kubernetes.io/instance: retriever-usvc
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/speecht5.yaml
+++ b/microservices-connector/config/manifests/speecht5.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: speecht5-config
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"
@@ -31,7 +31,7 @@ kind: Service
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"
@@ -56,7 +56,7 @@ kind: Deployment
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/speecht5_gaudi.yaml
+++ b/microservices-connector/config/manifests/speecht5_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: speecht5-config
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"
@@ -31,7 +31,7 @@ kind: Service
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"
@@ -56,7 +56,7 @@ kind: Deployment
 metadata:
   name: speecht5
   labels:
-    helm.sh/chart: speecht5-1.0.0
+    helm.sh/chart: speecht5-1.1.0
     app.kubernetes.io/name: speecht5
     app.kubernetes.io/instance: speecht5
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/tei.yaml
+++ b/microservices-connector/config/manifests/tei.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tei-config
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/tei_gaudi.yaml
+++ b/microservices-connector/config/manifests/tei_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tei-config
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -37,7 +37,7 @@ kind: Service
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"
@@ -62,7 +62,7 @@ kind: Deployment
 metadata:
   name: tei
   labels:
-    helm.sh/chart: tei-1.0.0
+    helm.sh/chart: tei-1.1.0
     app.kubernetes.io/name: tei
     app.kubernetes.io/instance: tei
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/teirerank.yaml
+++ b/microservices-connector/config/manifests/teirerank.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: teirerank-config
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/teirerank_gaudi.yaml
+++ b/microservices-connector/config/manifests/teirerank_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: teirerank-config
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -37,7 +37,7 @@ kind: Service
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"
@@ -62,7 +62,7 @@ kind: Deployment
 metadata:
   name: teirerank
   labels:
-    helm.sh/chart: teirerank-1.0.0
+    helm.sh/chart: teirerank-1.1.0
     app.kubernetes.io/name: teirerank
     app.kubernetes.io/instance: teirerank
     app.kubernetes.io/version: "cpu-1.5"

--- a/microservices-connector/config/manifests/tgi.yaml
+++ b/microservices-connector/config/manifests/tgi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -36,7 +36,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tgi_gaudi.yaml
+++ b/microservices-connector/config/manifests/tgi_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -43,7 +43,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -68,7 +68,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tgi_nv.yaml
+++ b/microservices-connector/config/manifests/tgi_nv.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tgi-config
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"
@@ -60,7 +60,7 @@ kind: Deployment
 metadata:
   name: tgi
   labels:
-    helm.sh/chart: tgi-1.0.0
+    helm.sh/chart: tgi-1.1.0
     app.kubernetes.io/name: tgi
     app.kubernetes.io/instance: tgi
     app.kubernetes.io/version: "2.1.0"

--- a/microservices-connector/config/manifests/tts.yaml
+++ b/microservices-connector/config/manifests/tts.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: tts-config
   labels:
-    helm.sh/chart: tts-1.0.0
+    helm.sh/chart: tts-1.1.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
     app.kubernetes.io/version: "v1.0"
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: tts
   labels:
-    helm.sh/chart: tts-1.0.0
+    helm.sh/chart: tts-1.1.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
     app.kubernetes.io/version: "v1.0"
@@ -54,7 +54,7 @@ kind: Deployment
 metadata:
   name: tts
   labels:
-    helm.sh/chart: tts-1.0.0
+    helm.sh/chart: tts-1.1.0
     app.kubernetes.io/name: tts
     app.kubernetes.io/instance: tts
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/ui.yaml
+++ b/microservices-connector/config/manifests/ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: ui
     app.kubernetes.io/version: "v1.0"
@@ -28,7 +28,7 @@ kind: Service
 metadata:
   name: ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: ui
     app.kubernetes.io/version: "v1.0"
@@ -53,7 +53,7 @@ kind: Deployment
 metadata:
   name: ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: ui
     app.kubernetes.io/version: "v1.0"
@@ -67,7 +67,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/visualqna_svelte-ui.yaml
+++ b/microservices-connector/config/manifests/visualqna_svelte-ui.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: visualqna-svelte-ui-config
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: visualqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: visualqna-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: visualqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -50,7 +50,7 @@ kind: Deployment
 metadata:
   name: visualqna-svelte-ui
   labels:
-    helm.sh/chart: ui-1.0.0
+    helm.sh/chart: ui-1.1.0
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: visualqna-svelte-ui
     app.kubernetes.io/version: "v1.0"
@@ -64,7 +64,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ui-1.0.0
+        helm.sh/chart: ui-1.1.0
         app.kubernetes.io/name: ui
         app.kubernetes.io/instance: visualqna-svelte-ui
         app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/vllm.yaml
+++ b/microservices-connector/config/manifests/vllm.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: vllm-config
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: vllm
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"
@@ -57,7 +57,7 @@ kind: Deployment
 metadata:
   name: vllm
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"

--- a/microservices-connector/config/manifests/vllm_gaudi.yaml
+++ b/microservices-connector/config/manifests/vllm_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: vllm-config
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"
@@ -34,7 +34,7 @@ kind: Service
 metadata:
   name: vllm
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"
@@ -59,7 +59,7 @@ kind: Deployment
 metadata:
   name: vllm
   labels:
-    helm.sh/chart: vllm-1.0.0
+    helm.sh/chart: vllm-1.1.0
     app.kubernetes.io/name: vllm
     app.kubernetes.io/instance: vllm
     app.kubernetes.io/version: "0.5"

--- a/microservices-connector/config/manifests/web-retriever.yaml
+++ b/microservices-connector/config/manifests/web-retriever.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: web-retriever-config
   labels:
-    helm.sh/chart: web-retriever-1.0.0
+    helm.sh/chart: web-retriever-1.1.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
     app.kubernetes.io/version: "v1.0"
@@ -33,7 +33,7 @@ kind: Service
 metadata:
   name: web-retriever
   labels:
-    helm.sh/chart: web-retriever-1.0.0
+    helm.sh/chart: web-retriever-1.1.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
     app.kubernetes.io/version: "v1.0"
@@ -58,7 +58,7 @@ kind: Deployment
 metadata:
   name: web-retriever
   labels:
-    helm.sh/chart: web-retriever-1.0.0
+    helm.sh/chart: web-retriever-1.1.0
     app.kubernetes.io/name: web-retriever
     app.kubernetes.io/instance: web-retriever
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/whisper.yaml
+++ b/microservices-connector/config/manifests/whisper.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: whisper-config
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"
@@ -31,7 +31,7 @@ kind: Service
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"
@@ -56,7 +56,7 @@ kind: Deployment
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/config/manifests/whisper_gaudi.yaml
+++ b/microservices-connector/config/manifests/whisper_gaudi.yaml
@@ -8,7 +8,7 @@ kind: ConfigMap
 metadata:
   name: whisper-config
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"
@@ -31,7 +31,7 @@ kind: Service
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"
@@ -56,7 +56,7 @@ kind: Deployment
 metadata:
   name: whisper
   labels:
-    helm.sh/chart: whisper-1.0.0
+    helm.sh/chart: whisper-1.1.0
     app.kubernetes.io/name: whisper
     app.kubernetes.io/instance: whisper
     app.kubernetes.io/version: "v1.0"

--- a/microservices-connector/helm/Chart.yaml
+++ b/microservices-connector/helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Description

Change labels & chart version to match / reduce diff to v1.1 release after c0a31210bb3d42bc1b457bead9bcd4983ba2726f.

(Needing to do this manually in `main` branch seems odd. IMHO bot should do this update to `main` at the same time it updates these, and image tags, in release branch.)

## Issues

`n/a`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`.

## Tests

Should already have been tested as part of v1.1rc branch?