### PR TITLE
[helm] don't use vllm service name

### DIFF
--- a/helm-charts/common/vllm/templates/service.yaml
+++ b/helm-charts/common/vllm/templates/service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "vllm.fullname" . }}
+  name: {{ include "vllm.fullname" . }}-{{"service"}}
   labels:
     {{- include "vllm.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
## Description

If vllm k8s service name is `vllm` bad things happen and the server fails to comeup with error message:

```console
ERROR 11-26 09:29:11 engine.py:366]     lambda: int(os.getenv('VLLM_PORT', '0'))
ERROR 11-26 09:29:11 engine.py:366] ValueError: invalid literal for int() with base 10: 'tcp://10.100.120.175:80'
```

See vllm [note](https://github.com/vllm-project/vllm/blob/main/docs/source/serving/env_vars.rst) about the service naming

## Issues

`na`  see above.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`na`

## Tests

Manually tested.
