### PR TITLE
helm: Add service account support - part1

### DIFF
--- a/helm-charts/common/agent/templates/deployment.yaml
+++ b/helm-charts/common/agent/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/agent/templates/serviceaccount.yaml
+++ b/helm-charts/common/agent/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/agent/values.yaml
+++ b/helm-charts/common/agent/values.yaml
@@ -40,6 +40,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/asr/templates/deployment.yaml
+++ b/helm-charts/common/asr/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "asr.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/asr/templates/serviceaccount.yaml
+++ b/helm-charts/common/asr/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "asr.serviceAccountName" . }}
+  labels:
+    {{- include "asr.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/asr/values.yaml
+++ b/helm-charts/common/asr/values.yaml
@@ -27,6 +27,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/chathistory-usvc/templates/deployment.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "chathistory-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/chathistory-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chathistory-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/chathistory-usvc/values.yaml
+++ b/helm-charts/common/chathistory-usvc/values.yaml
@@ -21,6 +21,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "data-prep.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/data-prep/templates/serviceaccount.yaml
+++ b/helm-charts/common/data-prep/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "data-prep.serviceAccountName" . }}
+  labels:
+    {{- include "data-prep.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -25,6 +25,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/embedding-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/embedding-usvc/templates/_helpers.tpl
@@ -53,9 +53,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "llm-uservice.serviceAccountName" -}}
+{{- define "embedding-usvc.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "llm-uservice.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "embedding-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "embedding-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/embedding-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/embedding-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "embedding-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "embedding-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -26,6 +26,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/gpt-sovits/templates/deployment.yaml
+++ b/helm-charts/common/gpt-sovits/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "gpt-sovits.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/gpt-sovits/templates/serviceaccount.yaml
+++ b/helm-charts/common/gpt-sovits/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gpt-sovits.serviceAccountName" . }}
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/gpt-sovits/values.yaml
+++ b/helm-charts/common/gpt-sovits/values.yaml
@@ -18,6 +18,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
## Description

Add service account support in the following helm charts:

- agent
- asr
- chathistory-usvc
- data-prep
- embedding-usvc
- gpt-sovits

## Issues

Fixes #532.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
