### PR TITLE
helm: Add service account support - part2

### DIFF
--- a/helm-charts/common/guardrails-usvc/templates/deployment.yaml
+++ b/helm-charts/common/guardrails-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "guardrails-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/guardrails-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/guardrails-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "guardrails-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "guardrails-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/guardrails-usvc/values.yaml
+++ b/helm-charts/common/guardrails-usvc/values.yaml
@@ -30,6 +30,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "llm-uservice.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/llm-uservice/templates/serviceaccount.yaml
+++ b/helm-charts/common/llm-uservice/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "llm-uservice.serviceAccountName" . }}
+  labels:
+    {{- include "llm-uservice.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -32,6 +32,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/lvm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/lvm-uservice/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "lvm-uservice.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/lvm-uservice/templates/serviceaccount.yaml
+++ b/helm-charts/common/lvm-uservice/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lvm-uservice.serviceAccountName" . }}
+  labels:
+    {{- include "lvm-uservice.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/lvm-uservice/values.yaml
+++ b/helm-charts/common/lvm-uservice/values.yaml
@@ -29,6 +29,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/mongodb/templates/deployment.yaml
+++ b/helm-charts/common/mongodb/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "mongodb.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/mongodb/templates/serviceaccount.yaml
+++ b/helm-charts/common/mongodb/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mongodb.serviceAccountName" . }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/mongodb/values.yaml
+++ b/helm-charts/common/mongodb/values.yaml
@@ -17,6 +17,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/prompt-usvc/templates/deployment.yaml
+++ b/helm-charts/common/prompt-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "prompt-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/prompt-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/prompt-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prompt-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/prompt-usvc/values.yaml
+++ b/helm-charts/common/prompt-usvc/values.yaml
@@ -21,6 +21,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/redis-vector-db/templates/deployment.yaml
+++ b/helm-charts/common/redis-vector-db/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "redis-vector-db.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/redis-vector-db/templates/serviceaccount.yaml
+++ b/helm-charts/common/redis-vector-db/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redis-vector-db.serviceAccountName" . }}
+  labels:
+    {{- include "redis-vector-db.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/redis-vector-db/values.yaml
+++ b/helm-charts/common/redis-vector-db/values.yaml
@@ -17,6 +17,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/reranking-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/reranking-usvc/templates/_helpers.tpl
@@ -53,9 +53,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "llm-uservice.serviceAccountName" -}}
+{{- define "reranking-usvc.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "llm-uservice.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "reranking-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "reranking-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/reranking-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/reranking-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "reranking-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "reranking-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -26,6 +26,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "retriever-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/retriever-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/retriever-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "retriever-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "retriever-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -35,6 +35,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/tts/templates/deployment.yaml
+++ b/helm-charts/common/tts/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "tts.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/tts/templates/serviceaccount.yaml
+++ b/helm-charts/common/tts/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tts.serviceAccountName" . }}
+  labels:
+    {{- include "tts.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/tts/values.yaml
+++ b/helm-charts/common/tts/values.yaml
@@ -27,6 +27,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/ui/templates/deployment.yaml
+++ b/helm-charts/common/ui/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "ui.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/ui/templates/serviceaccount.yaml
+++ b/helm-charts/common/ui/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ui.serviceAccountName" . }}
+  labels:
+    {{- include "ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/ui/values.yaml
+++ b/helm-charts/common/ui/values.yaml
@@ -18,6 +18,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/helm-charts/common/web-retriever/templates/deployment.yaml
+++ b/helm-charts/common/web-retriever/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "web-retriever.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/web-retriever/templates/serviceaccount.yaml
+++ b/helm-charts/common/web-retriever/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "web-retriever.serviceAccountName" . }}
+  labels:
+    {{- include "web-retriever.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/web-retriever/values.yaml
+++ b/helm-charts/common/web-retriever/values.yaml
@@ -29,6 +29,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
## Description

Add service account support in the following helm charts:

- guardrails-usvc
- llm-uservice
- lvm-uservice
- mongodb
- prompt-usvc
- redis-vector-db
- reranking-usvc
- retriever-usvc
- tts
- ui
- web-retriever


## Issues

Fixes #532.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
