### PR TITLE
helm chart: Add service account support

### DIFF
--- a/helm-charts/agentqna/templates/_helpers.tpl
+++ b/helm-charts/agentqna/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "agentqna.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "agentqna.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/agentqna/templates/crag.yaml
+++ b/helm-charts/agentqna/templates/crag.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "agentqna.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/agentqna/templates/docretriever.yaml
+++ b/helm-charts/agentqna/templates/docretriever.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "agentqna.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/agentqna/templates/serviceaccount.yaml
+++ b/helm-charts/agentqna/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentqna.serviceAccountName" . }}
+  labels:
+    {{- include "agentqna.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/agentqna/values.yaml
+++ b/helm-charts/agentqna/values.yaml
@@ -7,6 +7,26 @@
 
 replicaCount: 1
 
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
@@ -102,6 +122,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "agentqna"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/audioqna/templates/_helpers.tpl
+++ b/helm-charts/audioqna/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "audioqna.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "audioqna.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/audioqna/templates/deployment.yaml
+++ b/helm-charts/audioqna/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "audioqna.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/audioqna/templates/serviceaccount.yaml
+++ b/helm-charts/audioqna/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "audioqna.serviceAccountName" . }}
+  labels:
+    {{- include "audioqna.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/audioqna/values.yaml
+++ b/helm-charts/audioqna/values.yaml
@@ -14,14 +14,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-port: 8888
-service:
-  type: ClusterIP
-  port: 3008
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -33,6 +44,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 8888
+service:
+  type: ClusterIP
+  port: 3008
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -57,6 +77,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "audioqna"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/chatqna/templates/_helpers.tpl
+++ b/helm-charts/chatqna/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "chatqna.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "chatqna.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/chatqna/templates/deployment.yaml
+++ b/helm-charts/chatqna/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "chatqna.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/chatqna/templates/serviceaccount.yaml
+++ b/helm-charts/chatqna/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chatqna.serviceAccountName" . }}
+  labels:
+    {{- include "chatqna.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -14,14 +14,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-port: 8888
-service:
-  type: ClusterIP
-  port: 8888
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -33,6 +44,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 8888
+service:
+  type: ClusterIP
+  port: 8888
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -67,6 +87,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "chatqna"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/codegen/templates/_helpers.tpl
+++ b/helm-charts/codegen/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "codegen.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "codegen.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/codegen/templates/deployment.yaml
+++ b/helm-charts/codegen/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "codegen.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/codegen/templates/serviceaccount.yaml
+++ b/helm-charts/codegen/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "codegen.serviceAccountName" . }}
+  labels:
+    {{- include "codegen.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/codegen/values.yaml
+++ b/helm-charts/codegen/values.yaml
@@ -14,14 +14,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-port: 7778
-service:
-  type: ClusterIP
-  port: 7778
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -33,6 +44,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 7778
+service:
+  type: ClusterIP
+  port: 7778
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -56,6 +76,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "codegen"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/codetrans/templates/_helpers.tpl
+++ b/helm-charts/codetrans/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "codetrans.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "codetrans.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/codetrans/templates/deployment.yaml
+++ b/helm-charts/codetrans/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "codetrans.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/codetrans/templates/serviceaccount.yaml
+++ b/helm-charts/codetrans/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "codetrans.serviceAccountName" . }}
+  labels:
+    {{- include "codetrans.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/codetrans/values.yaml
+++ b/helm-charts/codetrans/values.yaml
@@ -15,14 +15,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-port: 7777
-service:
-  type: ClusterIP
-  port: 7777
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -34,6 +45,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 7777
+service:
+  type: ClusterIP
+  port: 7777
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -57,6 +77,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "codetrans"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/common/agent/templates/_helpers.tpl
+++ b/helm-charts/common/agent/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "agent.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/agent/templates/deployment.yaml
+++ b/helm-charts/common/agent/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/agent/templates/serviceaccount.yaml
+++ b/helm-charts/common/agent/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/agent/values.yaml
+++ b/helm-charts/common/agent/values.yaml
@@ -40,6 +40,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -105,6 +116,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/asr/templates/_helpers.tpl
+++ b/helm-charts/common/asr/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "asr.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "asr.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/asr/templates/deployment.yaml
+++ b/helm-charts/common/asr/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "asr.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/asr/templates/serviceaccount.yaml
+++ b/helm-charts/common/asr/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "asr.serviceAccountName" . }}
+  labels:
+    {{- include "asr.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/asr/values.yaml
+++ b/helm-charts/common/asr/values.yaml
@@ -27,6 +27,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -91,3 +102,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/chathistory-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/chathistory-usvc/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "chathistory-usvc.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "chathistory-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/chathistory-usvc/templates/deployment.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "chathistory-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/chathistory-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/chathistory-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chathistory-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "chathistory-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/chathistory-usvc/values.yaml
+++ b/helm-charts/common/chathistory-usvc/values.yaml
@@ -21,6 +21,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -94,3 +105,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/data-prep/templates/_helpers.tpl
+++ b/helm-charts/common/data-prep/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "data-prep.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "data-prep.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/data-prep/templates/deployment.yaml
+++ b/helm-charts/common/data-prep/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "data-prep.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/data-prep/templates/serviceaccount.yaml
+++ b/helm-charts/common/data-prep/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "data-prep.serviceAccountName" . }}
+  labels:
+    {{- include "data-prep.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -25,6 +25,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -113,3 +124,7 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/embedding-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/embedding-usvc/templates/_helpers.tpl
@@ -53,9 +53,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "llm-uservice.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "llm-uservice.fullname" .) .Values.serviceAccount.name }}
+{{- define "embedding-usvc.serviceAccountName" -}}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
+{{- default (include "embedding-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/helm-charts/common/embedding-usvc/templates/deployment.yaml
+++ b/helm-charts/common/embedding-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "embedding-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/embedding-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/embedding-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "embedding-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "embedding-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/embedding-usvc/values.yaml
+++ b/helm-charts/common/embedding-usvc/values.yaml
@@ -26,6 +26,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -90,6 +101,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/gpt-sovits/templates/_helpers.tpl
+++ b/helm-charts/common/gpt-sovits/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "gpt-sovits.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "gpt-sovits.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/gpt-sovits/templates/deployment.yaml
+++ b/helm-charts/common/gpt-sovits/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "gpt-sovits.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/gpt-sovits/templates/serviceaccount.yaml
+++ b/helm-charts/common/gpt-sovits/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gpt-sovits.serviceAccountName" . }}
+  labels:
+    {{- include "gpt-sovits.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/gpt-sovits/values.yaml
+++ b/helm-charts/common/gpt-sovits/values.yaml
@@ -18,6 +18,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -81,3 +92,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/guardrails-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/guardrails-usvc/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "guardrails-usvc.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "guardrails-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/guardrails-usvc/templates/deployment.yaml
+++ b/helm-charts/common/guardrails-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "guardrails-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/guardrails-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/guardrails-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "guardrails-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "guardrails-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/guardrails-usvc/values.yaml
+++ b/helm-charts/common/guardrails-usvc/values.yaml
@@ -30,6 +30,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -94,3 +105,7 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/llm-uservice/templates/_helpers.tpl
+++ b/helm-charts/common/llm-uservice/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "llm-uservice.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "llm-uservice.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/llm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/llm-uservice/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "llm-uservice.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/llm-uservice/templates/serviceaccount.yaml
+++ b/helm-charts/common/llm-uservice/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "llm-uservice.serviceAccountName" . }}
+  labels:
+    {{- include "llm-uservice.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/llm-uservice/values.yaml
+++ b/helm-charts/common/llm-uservice/values.yaml
@@ -32,6 +32,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -97,6 +108,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/lvm-uservice/templates/_helpers.tpl
+++ b/helm-charts/common/lvm-uservice/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "lvm-uservice.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "lvm-uservice.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/lvm-uservice/templates/deployment.yaml
+++ b/helm-charts/common/lvm-uservice/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "lvm-uservice.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/lvm-uservice/templates/serviceaccount.yaml
+++ b/helm-charts/common/lvm-uservice/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lvm-uservice.serviceAccountName" . }}
+  labels:
+    {{- include "lvm-uservice.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/lvm-uservice/values.yaml
+++ b/helm-charts/common/lvm-uservice/values.yaml
@@ -29,6 +29,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -94,6 +105,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/mongodb/templates/_helpers.tpl
+++ b/helm-charts/common/mongodb/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "mongodb.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "mongodb.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/mongodb/templates/deployment.yaml
+++ b/helm-charts/common/mongodb/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "mongodb.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/mongodb/templates/serviceaccount.yaml
+++ b/helm-charts/common/mongodb/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mongodb.serviceAccountName" . }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/mongodb/values.yaml
+++ b/helm-charts/common/mongodb/values.yaml
@@ -17,6 +17,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -60,3 +71,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+global:
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/prompt-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/prompt-usvc/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "prompt-usvc.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "prompt-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/prompt-usvc/templates/deployment.yaml
+++ b/helm-charts/common/prompt-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "prompt-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/prompt-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/prompt-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prompt-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "prompt-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/prompt-usvc/values.yaml
+++ b/helm-charts/common/prompt-usvc/values.yaml
@@ -21,6 +21,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -97,3 +108,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/redis-vector-db/templates/_helpers.tpl
+++ b/helm-charts/common/redis-vector-db/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "redis-vector-db.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "redis-vector-db.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/redis-vector-db/templates/deployment.yaml
+++ b/helm-charts/common/redis-vector-db/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "redis-vector-db.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/redis-vector-db/templates/serviceaccount.yaml
+++ b/helm-charts/common/redis-vector-db/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redis-vector-db.serviceAccountName" . }}
+  labels:
+    {{- include "redis-vector-db.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/redis-vector-db/values.yaml
+++ b/helm-charts/common/redis-vector-db/values.yaml
@@ -17,6 +17,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -61,3 +72,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+global:
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/reranking-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/reranking-usvc/templates/_helpers.tpl
@@ -53,9 +53,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "llm-uservice.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "llm-uservice.fullname" .) .Values.serviceAccount.name }}
+{{- define "reranking-usvc.serviceAccountName" -}}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
+{{- default (include "reranking-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/helm-charts/common/reranking-usvc/templates/deployment.yaml
+++ b/helm-charts/common/reranking-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "reranking-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/reranking-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/reranking-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "reranking-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "reranking-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/reranking-usvc/values.yaml
+++ b/helm-charts/common/reranking-usvc/values.yaml
@@ -26,6 +26,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -90,6 +101,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/retriever-usvc/templates/_helpers.tpl
+++ b/helm-charts/common/retriever-usvc/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "retriever-usvc.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "retriever-usvc.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/retriever-usvc/templates/deployment.yaml
+++ b/helm-charts/common/retriever-usvc/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "retriever-usvc.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/retriever-usvc/templates/serviceaccount.yaml
+++ b/helm-charts/common/retriever-usvc/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "retriever-usvc.serviceAccountName" . }}
+  labels:
+    {{- include "retriever-usvc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/retriever-usvc/values.yaml
+++ b/helm-charts/common/retriever-usvc/values.yaml
@@ -35,6 +35,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -108,6 +119,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Install Prometheus serviceMonitor for service
   monitoring: false

--- a/helm-charts/common/speecht5/templates/_helpers.tpl
+++ b/helm-charts/common/speecht5/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "speecht5.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "speecht5.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/speecht5/templates/deployment.yaml
+++ b/helm-charts/common/speecht5/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "speecht5.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/speecht5/templates/serviceaccount.yaml
+++ b/helm-charts/common/speecht5/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "speecht5.serviceAccountName" . }}
+  labels:
+    {{- include "speecht5.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/speecht5/values.yaml
+++ b/helm-charts/common/speecht5/values.yaml
@@ -21,6 +21,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -85,6 +96,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/common/tei/templates/_helpers.tpl
+++ b/helm-charts/common/tei/templates/_helpers.tpl
@@ -61,7 +61,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "tei.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "tei.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/tei/templates/deployment.yaml
+++ b/helm-charts/common/tei/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "tei.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/tei/templates/serviceaccount.yaml
+++ b/helm-charts/common/tei/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tei.serviceAccountName" . }}
+  labels:
+    {{- include "tei.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -35,6 +35,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -99,6 +110,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/common/teirerank/templates/_helpers.tpl
+++ b/helm-charts/common/teirerank/templates/_helpers.tpl
@@ -61,7 +61,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "teirerank.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "teirerank.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/teirerank/templates/deployment.yaml
+++ b/helm-charts/common/teirerank/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "teirerank.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/teirerank/templates/serviceaccount.yaml
+++ b/helm-charts/common/teirerank/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "teirerank.serviceAccountName" . }}
+  labels:
+    {{- include "teirerank.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -35,6 +35,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -99,6 +110,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/common/tgi/templates/_helpers.tpl
+++ b/helm-charts/common/tgi/templates/_helpers.tpl
@@ -61,7 +61,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "tgi.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "tgi.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/tgi/templates/deployment.yaml
+++ b/helm-charts/common/tgi/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "tgi.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/tgi/templates/serviceaccount.yaml
+++ b/helm-charts/common/tgi/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tgi.serviceAccountName" . }}
+  labels:
+    {{- include "tgi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -36,6 +36,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -129,6 +140,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/common/tts/templates/_helpers.tpl
+++ b/helm-charts/common/tts/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "tts.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "tts.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/tts/templates/deployment.yaml
+++ b/helm-charts/common/tts/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "tts.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/tts/templates/serviceaccount.yaml
+++ b/helm-charts/common/tts/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tts.serviceAccountName" . }}
+  labels:
+    {{- include "tts.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/tts/values.yaml
+++ b/helm-charts/common/tts/values.yaml
@@ -27,6 +27,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -91,3 +102,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/ui/templates/_helpers.tpl
+++ b/helm-charts/common/ui/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "ui.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "ui.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/ui/templates/deployment.yaml
+++ b/helm-charts/common/ui/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "ui.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/ui/templates/serviceaccount.yaml
+++ b/helm-charts/common/ui/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ui.serviceAccountName" . }}
+  labels:
+    {{- include "ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/ui/values.yaml
+++ b/helm-charts/common/ui/values.yaml
@@ -18,6 +18,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -96,4 +107,8 @@ DATAPREP_GET_FILE_ENDPOINT: "/v1/dataprep/get_file"
 # data preparation delete file service URL, default to Mega data preparation service
 DATAPREP_DELETE_FILE_ENDPOINT: "/v1/dataprep/delete_file"
 
-global: {}
+global:
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/vllm/templates/_helpers.tpl
+++ b/helm-charts/common/vllm/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "vllm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "vllm.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/vllm/templates/deployment.yaml
+++ b/helm-charts/common/vllm/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "vllm.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/vllm/templates/serviceaccount.yaml
+++ b/helm-charts/common/vllm/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vllm.serviceAccountName" . }}
+  labels:
+    {{- include "vllm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/vllm/values.yaml
+++ b/helm-charts/common/vllm/values.yaml
@@ -20,6 +20,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -88,6 +99,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/common/web-retriever/templates/_helpers.tpl
+++ b/helm-charts/common/web-retriever/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "web-retriever.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "web-retriever.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/web-retriever/templates/deployment.yaml
+++ b/helm-charts/common/web-retriever/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "web-retriever.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/web-retriever/templates/serviceaccount.yaml
+++ b/helm-charts/common/web-retriever/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "web-retriever.serviceAccountName" . }}
+  labels:
+    {{- include "web-retriever.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/web-retriever/values.yaml
+++ b/helm-charts/common/web-retriever/values.yaml
@@ -29,6 +29,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -93,3 +104,7 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""

--- a/helm-charts/common/whisper/templates/_helpers.tpl
+++ b/helm-charts/common/whisper/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "whisper.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "whisper.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/common/whisper/templates/deployment.yaml
+++ b/helm-charts/common/whisper/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "whisper.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/common/whisper/templates/serviceaccount.yaml
+++ b/helm-charts/common/whisper/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "whisper.serviceAccountName" . }}
+  labels:
+    {{- include "whisper.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/common/whisper/values.yaml
+++ b/helm-charts/common/whisper/values.yaml
@@ -20,6 +20,17 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -84,6 +95,10 @@ global:
   http_proxy: ""
   https_proxy: ""
   no_proxy: ""
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: ""
 
   # Choose where to save your downloaded models
   # Set modelUseHostPath for local directory, this is good for one node test. Example:

--- a/helm-charts/docsum/templates/_helpers.tpl
+++ b/helm-charts/docsum/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "docsum.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "docsum.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/docsum/templates/deployment.yaml
+++ b/helm-charts/docsum/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "docsum.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/docsum/templates/m2t.yaml
+++ b/helm-charts/docsum/templates/m2t.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "docsum.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/docsum/templates/serviceaccount.yaml
+++ b/helm-charts/docsum/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "docsum.serviceAccountName" . }}
+  labels:
+    {{- include "docsum.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/docsum/templates/v2a.yaml
+++ b/helm-charts/docsum/templates/v2a.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "docsum.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/docsum/values.yaml
+++ b/helm-charts/docsum/values.yaml
@@ -33,14 +33,25 @@ m2t:
     type: ClusterIP
     port: 7079
 
-port: 8888
-service:
-  type: ClusterIP
-  port: 8888
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -52,6 +63,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 8888
+service:
+  type: ClusterIP
+  port: 8888
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -80,6 +100,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "docsum"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/faqgen/templates/_helpers.tpl
+++ b/helm-charts/faqgen/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "faqgen.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "faqgen.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/faqgen/templates/deployment.yaml
+++ b/helm-charts/faqgen/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "faqgen.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/faqgen/templates/serviceaccount.yaml
+++ b/helm-charts/faqgen/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "faqgen.serviceAccountName" . }}
+  labels:
+    {{- include "faqgen.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/faqgen/values.yaml
+++ b/helm-charts/faqgen/values.yaml
@@ -14,14 +14,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-port: 8888
-service:
-  type: ClusterIP
-  port: 8888
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
 
-nginx:
-  service:
-    type: NodePort
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -33,6 +44,15 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+port: 8888
+service:
+  type: ClusterIP
+  port: 8888
+
+nginx:
+  service:
+    type: NodePort
 
 nodeSelector: {}
 
@@ -61,6 +81,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "faqgen"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models

--- a/helm-charts/visualqna/templates/_helpers.tpl
+++ b/helm-charts/visualqna/templates/_helpers.tpl
@@ -54,7 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "visualqna.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.global.sharedSAName }}
+{{- .Values.global.sharedSAName }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "visualqna.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/helm-charts/visualqna/templates/deployment.yaml
+++ b/helm-charts/visualqna/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "visualqna.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm-charts/visualqna/templates/serviceaccount.yaml
+++ b/helm-charts/visualqna/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "visualqna.serviceAccountName" . }}
+  labels:
+    {{- include "visualqna.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/visualqna/values.yaml
+++ b/helm-charts/visualqna/values.yaml
@@ -14,13 +14,25 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
-nginx:
-  service:
-    type: NodePort
-port: 8888
-service:
-  type: ClusterIP
-  port: 8888
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
 
 securityContext:
   readOnlyRootFilesystem: true
@@ -32,6 +44,14 @@ securityContext:
     - ALL
   seccompProfile:
     type: RuntimeDefault
+
+nginx:
+  service:
+    type: NodePort
+port: 8888
+service:
+  type: ClusterIP
+  port: 8888
 
 nodeSelector: {}
 
@@ -62,6 +82,10 @@ global:
   https_proxy: ""
   no_proxy: ""
   HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
+  # service account name to be shared with all parent/child charts.
+  # If set, it will overwrite serviceAccount.name.
+  # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
+  sharedSAName: "visualqna"
   # set modelUseHostPath or modelUsePVC to use model cache.
   modelUseHostPath: ""
   # modelUseHostPath: /mnt/opea-models


### PR DESCRIPTION
## Description

1. Add service account support disabled by default for all common charts, enabled by default for all e2e charts.

2. Add support of sharing the same service account by setting `global.sharedSAName`, disabled by default for all common charts, enabled by default for all e2e charts.

## Issues

Fixes #532.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

n/a.

## Tests

Describe the tests that you ran to verify your changes.
