### PR TITLE
Improve dashboard upload script

### DIFF
--- a/kubernetes-addons/Observability/README.md
+++ b/kubernetes-addons/Observability/README.md
@@ -122,7 +122,7 @@ You can either:
 
 - Import them manually to Grafana,
 - Use [`update-dashboards.sh`](./update-dashboards.sh) script to add them to Kubernetes as (more persistent) Grafana dashboard `configMap`s
-  - Script uses `$USER-<file name>` as dashboard `configMap` names, overwrites any pre-existing `configMap` with the same name, and _restarts Grafana_ so that it notices `configMap` updates
+  - Script uses `$USER-<file name>` as dashboard `configMap` names, and overwrites any pre-existing `configMap` with the same name
 - Or create your own dashboards based on them
 
 When dashboard is imported to Grafana, you can directly save changes to it, but such dashboards go away if Grafana is removed / re-installed. When dashboard is in `configMap`, Grafana saves its changes to a (selected) file, but you need to re-apply those files to Kubernetes with the script, for your changes to be there when that Grafana dashboard page is reloaded in browser.
@@ -130,8 +130,8 @@ When dashboard is imported to Grafana, you can directly save changes to it, but 
 Gotchas for dashboard `configMap` script usage:
 
 - If you change dashboard file name, you need to change also its 'uid' field (at end of the file), otherwise Grafana will see multiple `configMap`s for the same dashboard ID
-  - If there's no `uid` specified for the dashboard, Grafana will generate one on `configMap` load. Meaning that dashboard ID, and Grafana URL to it, will change on every reload
-- Script assumes Prometheus / Grafana to be installed according to above instructions. If not, list of `labels` within script need to be updated to match Prometheus / Grafana installation
+- If there's no `uid` specified for the dashboard, Grafana will generate one on `configMap` load. Meaning that dashboard ID, and Grafana URL to it, will change on every reload
+- Script assumes default Prometheus / Grafana install (`monitoring` namespace, `grafana_dasboard=1` label identifying dashboard `configMap`s)
 
 NOTE: Services provide metrics only after they have processed at least one query, before that dashboards can be empty!
 


### PR DESCRIPTION
## Description

Single `configMap` label is enough, and Grafana does not need to be restarted, one just needs to wait enough for it to check+process new `configMap`s & do Grafana page reload.

=> Updated script + README accordingly.

## Issues

Grafana restart had following usability issues:
* It breaks Grafana instance `kubectl port-forward`ing for everybody using it at the same time
* If dashboard does not have an UID, i.e. restarted Grafana generates a new UID, URL for such dashboards change

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`.

## Tests

Tested script manually with new and updated dashboard JSONs.