### PR TITLE
README: add links to terraform docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following steps are optional. They're only required if you want to run the w
 
    NOTE: Make sure you configure the appropriate container runtime based on the type of container runtime you installed during Kubernetes setup.
 
-4. [Install Intel Gaudi device plugin for Kubernetes](https://docs.habana.ai/en/latest/Orchestration/Gaudi_Kubernetes/Device_Plugin_for_Kubernetes.html).
+4. [Install Intel Gaudi device plugin for Kubernetes](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Kubernetes_Installation/index.html).
 
    Alternatively, Intel provides a base operator to manage the Gaudi software stack. Refer to [this file](kubernetes-addons/Intel-Gaudi-Base-Operator/README.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ To deploy GenAIExamples to Kubernetes using helm charts, you need [Helm](https:/
 
 For a detailed version, see [Deploy GenAIExample/GenAIComps using helm charts](https://github.com/opea-project/GenAIInfra/tree/main/helm-charts/README.md)
 
+### Use terraform to deploy on cloud service providers
+
+You can use [Terraform](https://www.terraform.io/) to create infrastruture to run OPEA applications on various cloud service provider (CSP) environments.
+
+* [AWS/EKS: Create managed Kubernetes cluster on AWS for OPEA](https://github.com/opea-project/GenAIInfra/blob/main/cloud-service-provider/aws/eks/terraform/README.MD)
+
+
 ## Additional Content
 
 - [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ For a detailed version, see [Deploy GenAIExample/GenAIComps using helm charts](h
 
 ### Use terraform to deploy on cloud service providers
 
-You can use [Terraform](https://www.terraform.io/) to create infrastruture to run OPEA applications on various cloud service provider (CSP) environments.
+You can use [Terraform](https://www.terraform.io/) to create infrastructure to run OPEA applications on various cloud service provider (CSP) environments.
 
-* [AWS/EKS: Create managed Kubernetes cluster on AWS for OPEA](https://github.com/opea-project/GenAIInfra/blob/main/cloud-service-provider/aws/eks/terraform/README.MD)
-
+- [AWS/EKS: Create managed Kubernetes cluster on AWS for OPEA](https://github.com/opea-project/GenAIInfra/blob/main/cloud-service-provider/aws/eks/terraform/README.MD)
 
 ## Additional Content
 


### PR DESCRIPTION
## Description

Add links to terraform modules so they can be linked to OPEA documentation.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`.

## Tests

Manual testing: doc looks okay and link works.
