### PR TITLE
Add monitoring for rest of ChatQnA + DocSum components

### DIFF
--- a/helm-charts/common/data-prep/README.md
+++ b/helm-charts/common/data-prep/README.md
@@ -46,12 +46,13 @@ curl http://localhost:6007/v1/dataprep  \
 
 ## Values
 
-| Key                    | Type   | Default                 | Description |
-| ---------------------- | ------ | ----------------------- | ----------- |
-| image.repository       | string | `"opea/dataprep-redis"` |             |
-| service.port           | string | `"6007"`                |             |
-| REDIS_URL              | string | `""`                    |             |
-| TEI_EMBEDDING_ENDPOINT | string | `""`                    |             |
+| Key                    | Type   | Default                 | Description                              |
+| ---------------------- | ------ | ----------------------- | ---------------------------------------- |
+| image.repository       | string | `"opea/dataprep-redis"` |                                          |
+| service.port           | string | `"6007"`                |                                          |
+| REDIS_URL              | string | `""`                    |                                          |
+| TEI_EMBEDDING_ENDPOINT | string | `""`                    |                                          |
+| global.monitoring      | bool   | `false`                 | See ../../monitoring.md before enabling! |
 
 ## Milvus support
 

--- a/helm-charts/common/data-prep/templates/servicemonitor.yaml
+++ b/helm-charts/common/data-prep/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "data-prep.fullname" . }}
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "data-prep.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: data-prep
+    interval: 5s
+{{- end }}

--- a/helm-charts/common/data-prep/values.yaml
+++ b/helm-charts/common/data-prep/values.yaml
@@ -128,3 +128,9 @@ global:
   # If set, it will overwrite serviceAccount.name.
   # If set, and serviceAccount.create is false, it will assume this service account is already created by others.
   sharedSAName: ""
+
+  # Install Prometheus serviceMonitors for service components
+  monitoring: false
+
+  # Prometheus Helm install release name needed for serviceMonitors
+  prometheusRelease: prometheus-stack

--- a/helm-charts/docsum/templates/m2t.yaml
+++ b/helm-charts/docsum/templates/m2t.yaml
@@ -85,6 +85,7 @@ metadata:
   name: {{ .Release.Name }}-m2t
   labels:
     {{- include "docsum.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}-m2t
 spec:
   type: {{ .Values.m2t.service.type }}
   ports:
@@ -95,3 +96,20 @@ spec:
   selector:
     {{- include "docsum.selectorLabels" . | nindent 4 }}
     app: {{ .Release.Name }}-m2t
+---
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "docsum.fullname" . }}-m2t
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "docsum.selectorLabels" . | nindent 6 }}
+      app: {{ .Release.Name }}-m2t
+  endpoints:
+  - port: m2t
+    interval: 5s
+{{- end }}

--- a/helm-charts/docsum/templates/v2a.yaml
+++ b/helm-charts/docsum/templates/v2a.yaml
@@ -80,6 +80,7 @@ metadata:
   name: {{ .Release.Name }}-v2a
   labels:
     {{- include "docsum.labels" . | nindent 4 }}
+    app: {{ .Release.Name }}-v2a
 spec:
   type: {{ .Values.v2a.service.type }}
   ports:
@@ -90,3 +91,20 @@ spec:
   selector:
     {{- include "docsum.selectorLabels" . | nindent 4 }}
     app: {{ .Release.Name }}-v2a
+---
+{{- if .Values.global.monitoring }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "docsum.fullname" . }}-v2a
+  labels:
+    release: {{ .Values.global.prometheusRelease }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "docsum.selectorLabels" . | nindent 6 }}
+      app: {{ .Release.Name }}-v2a
+  endpoints:
+  - port: v2a
+    interval: 5s
+{{- end }}


### PR DESCRIPTION
## Description

ChatQnA + DocSum had few components which provide metrics endpoint, but did not have Prometheus `serviceMonitor`s for (optional) collection of those metrics.  This adds them.

## Issues

`n/a`.

## Type of change

- [X] New feature (non-breaking change which adds new functionality)

## Dependencies

`n/a`.

## Tests

Manual testing with `latest` images.

## Next steps

These components use `MicroService` class, so they provide metrics both from that and underlying HTTP service.  

However, because they don't process any tokens with `MicroService`, its metrics are always zero.  I'll try to come up with some way to skip exporting them from `MicroService` in "GenAIComps".