### PR TITLE
Unblock doc CI

### DIFF
--- a/.github/workflows/check-online-doc-build.yml
+++ b/.github/workflows/check-online-doc-build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout


### PR DESCRIPTION
## Description

Pin to run on ubuntu 22.04 since docc CI doesn't support python 3.12 in ubuntu 24.04.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
