### PR TITLE
HPA enabling usability improvement

### DIFF
--- a/helm-charts/HPA.md
+++ b/helm-charts/HPA.md
@@ -30,8 +30,8 @@ HPA controlled _CPU_ pods SHOULD have appropriate resource requests or affinity 
 subcharts and tested to work) so that k8s scheduler does not schedule too many of them on the same
 node(s). Otherwise they never reach ready state.
 
-If you use different models than the default ones, update TGI and TEI resource requests to match
-model requirements.
+If you use different models than the default ones, update inferencing services (vLLM, TGI, TEI) resource
+requests to match model requirements.
 
 Too large requests would not be a problem as long as pods still fit to available nodes. However,
 unless rules have been added to pods preventing them from being scheduled on same nodes, too
@@ -142,7 +142,7 @@ $ kubectl -n $prom_ns delete $(kubectl -n $prom_ns get pod --selector $selector 
 After [verifying that service metrics work](monitoring.md#verify),
 one can verify that HPA rules can access custom metrics based on them.
 
-Verify that there are (TGI and/or TEI) custom metrics prefixed with chart name:
+Verify that there are custom metrics from inferencing service(s), prefixed with the chart name:
 
 ```console
 $ kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1 | jq .resources[].name
@@ -154,3 +154,6 @@ And HPA rules have TARGET values for HPA controlled service deployments (instead
 $ ns=default  # OPEA namespace
 $ kubectl -n $ns get hpa
 ```
+
+**NOTE**: inferencing services provide metrics only after they've processed their first request.
+And reranking service is used only after query context data has been uploaded!

--- a/helm-charts/chatqna/hpa-values.yaml
+++ b/helm-charts/chatqna/hpa-values.yaml
@@ -12,6 +12,10 @@
 autoscaling:
   enabled: true
 
+global:
+  # K8s custom metrics (used for scaling thresholds) are based on metrics from service monitoring
+  monitoring: true
+
 # Override values in specific subcharts
 
 # Enabling "autoscaling" for any of the subcharts requires enabling it also above!

--- a/helm-charts/monitoring.md
+++ b/helm-charts/monitoring.md
@@ -47,7 +47,7 @@ or in its `values.yaml` file. Otherwise Prometheus ignores the installed
 
 ## Install
 
-Install Helm chart with `global.monitoring:true` option.
+Install Helm chart with `--set global.monitoring=true` option.
 
 ## Verify
 
@@ -91,5 +91,5 @@ $ curl --no-progress-meter $prom_url/api/v1/query? \
   --data-urlencode 'query=tgi_queue_size{service="'$chart'-tgi"}' | jq
 ```
 
-**NOTE**: services provide metrics only after they've processed their first request.
-And ChatQnA uses (TEI) reranking service only after query context data has been uploaded!
+**NOTE**: inferencing services provide metrics only after they've processed their first request.
+And reranking service only after query context data has been uploaded!


### PR DESCRIPTION
## Description

* HPA requires metrics, so enable `monitoring` automatically in `hpa-values.yaml`
* Minor updates to docs

## Issues

`n/a`.

## Type of change

`n/a`.

## Dependencies

`n/a`.

## Tests

Verified that the Helm generated manifests with the updated `hpa-values.yaml` are identical to ones generated earlier with `--set global.monitoring=true` option.