### PR TITLE
CI: exclude library charts from chart-lint

### DIFF
--- a/.github/workflows/pr-chart-validate.yaml
+++ b/.github/workflows/pr-chart-validate.yaml
@@ -53,6 +53,11 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm-charts/update_dependency.sh
-          ct lint --check-version-increment=false --validate-maintainers=false --chart-dirs ${{ env.CHARTS_DIRS }} --target-branch ${{ github.event.repository.default_branch }} \
+          exclude_param=""
+          for libchart in `find helm-charts/ -name "Chart.yaml" | xargs grep -rl '^type:.*library' | xargs grep '^name:' | awk '{print $2}' `
+          do
+              exclude_param="${exclude_param} --excluded-charts $libchart"
+          done
+          ct lint ${exclude_param} --check-version-increment=false --validate-maintainers=false --chart-dirs ${{ env.CHARTS_DIRS }} --target-branch ${{ github.event.repository.default_branch }} \
               --chart-repos milvus=https://zilliztech.github.io/milvus-helm \
               --chart-repos qdrant=https://qdrant.github.io/qdrant-helm


### PR DESCRIPTION
## Description

Exclude library charts from chart-lint since they don't have values files.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
