### PR TITLE
Add minReplicas option for rest of autoscalable components

### DIFF
--- a/helm-charts/chatqna/hpa-values.yaml
+++ b/helm-charts/chatqna/hpa-values.yaml
@@ -24,17 +24,21 @@ global:
 # Enabling "autoscaling" for any of the subcharts requires enabling it also above!
 vllm:
   autoscaling:
+    minReplicas: 1
     maxReplicas: 4
     enabled: true
 tgi:
   autoscaling:
+    minReplicas: 1
     maxReplicas: 4
     enabled: true
 teirerank:
   autoscaling:
+    minReplicas: 1
     maxReplicas: 3
     enabled: true
 tei:
   autoscaling:
+    minReplicas: 1
     maxReplicas: 2
     enabled: true

--- a/helm-charts/common/lvm-serve/values.yaml
+++ b/helm-charts/common/lvm-serve/values.yaml
@@ -146,13 +146,9 @@ startupProbe:
   periodSeconds: 5
   failureThreshold: 120
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: Do not use (above) "replicaCount" with HPA (Chart ignores value=1 as it's k8s default)
-# Note: Because HPA can sometimes change replica counts up and down rather frequently, the microservice needs to handle SIGTERM elegantly:
-# - stop accepting new requests
-# - handle all of its buffered requests
-# - terminate after tthose have been processed
-# See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination.
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/helm-charts/common/mm-embedding/values.yaml
+++ b/helm-charts/common/mm-embedding/values.yaml
@@ -100,8 +100,9 @@ startupProbe:
   periodSeconds: 5
   failureThreshold: 120
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: Do not use (above) "replicaCount" with HPA (Chart ignores value=1 as it's k8s default)
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/helm-charts/common/nginx/values.yaml
+++ b/helm-charts/common/nginx/values.yaml
@@ -73,8 +73,9 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: do not use (above) "replicaCount" with HPA (Chart ignores value=1 as it's k8s default)
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/helm-charts/common/ollama/values.yaml
+++ b/helm-charts/common/ollama/values.yaml
@@ -100,13 +100,9 @@ resources: {}
 #     path: /api/version
 #     port: http
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: Do not use (above) "replicaCount" with HPA (Chart ignores value=1 as it's k8s default)
-# Note: Because HPA can sometimes change replica counts up and down rather frequently, the microservice needs to handle SIGTERM elegantly:
-# - stop accepting new requests
-# - handle all of its buffered requests
-# - terminate after tthose have been processed
-# See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination.
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/helm-charts/common/tei/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/tei/templates/horizontal-pod-autoscaler.yaml
@@ -11,7 +11,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "tei.fullname" . }}
-  minReplicas: 1
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
   - type: Object

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -7,11 +7,12 @@
 
 replicaCount: 1
 
-# Enabling HPA will:
-# - Ignore above replica count, as it will be controlled by HPA
-# - Add example HPA scaling rules with custom metrics thresholds
-# - Require custom metrics ConfigMap available in the main application chart
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - Requires custom metrics ConfigMap available in the main application chart
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  minReplicas: 1
   maxReplicas: 2
   enabled: false
 

--- a/helm-charts/common/teirerank/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/teirerank/templates/horizontal-pod-autoscaler.yaml
@@ -11,7 +11,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "teirerank.fullname" . }}
-  minReplicas: 1
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
   - type: Object

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -7,11 +7,12 @@
 
 replicaCount: 1
 
-# Enabling HPA will:
-# - Ignore above replica count, as it will be controlled by HPA
-# - Add example HPA scaling rules with custom metrics thresholds
-# - Require custom metrics ConfigMap available in the main application chart
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - Requires custom metrics ConfigMap available in the main application chart
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  minReplicas: 1
   maxReplicas: 3
   enabled: false
 

--- a/helm-charts/common/text2image/values.yaml
+++ b/helm-charts/common/text2image/values.yaml
@@ -94,13 +94,9 @@ startupProbe:
   periodSeconds: 5
   failureThreshold: 120
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: Do not use (above) "replicaCount" with HPA (Chart ignores value=1 as it's k8s default)
-# Note: Because HPA can sometimes change replica counts up and down rather frequently, the microservice needs to handle SIGTERM elegantly:
-# - stop accepting new requests
-# - handle all of its buffered requests
-# - terminate after tthose have been processed
-# See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination.
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: false
   minReplicas: 1

--- a/helm-charts/common/tgi/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/tgi/templates/horizontal-pod-autoscaler.yaml
@@ -11,7 +11,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "tgi.fullname" . }}
-  minReplicas: 1
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
   - type: Object

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -7,11 +7,12 @@
 
 replicaCount: 1
 
-# Enabling HPA will:
-# - Ignore above replica count, as it will be controlled by HPA
-# - Add example HPA scaling rules with custom metrics thresholds
-# - Require custom metrics ConfigMap available in the main application chart
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - Requires custom metrics ConfigMap available in the main application chart
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  minReplicas: 1
   maxReplicas: 4
   enabled: false
 

--- a/helm-charts/common/vllm/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/vllm/templates/horizontal-pod-autoscaler.yaml
@@ -11,7 +11,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "vllm.fullname" . }}
-  minReplicas: 1
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
   - type: Object

--- a/helm-charts/common/vllm/values.yaml
+++ b/helm-charts/common/vllm/values.yaml
@@ -7,11 +7,12 @@
 
 replicaCount: 1
 
-# Enabling HPA will:
-# - Ignore above replica count, as it will be controlled by HPA
-# - Add example HPA scaling rules with custom metrics thresholds
-# - Require custom metrics ConfigMap available in the main application chart
+# Service autoscaling with HorizontalPodAutoscaler (HPA):
+# - Do not use "replicaCount" with HPA (value=1 is ignored as it's k8s default)
+# - Requires custom metrics ConfigMap available in the main application chart
+# - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  minReplicas: 1
   maxReplicas: 4
   enabled: false
 


### PR DESCRIPTION
## Description

* Add minReplicas option for all autoscalable components
* Use same explanation/comments for all of them
* Remove statements about the required service scale down termination handling
  - It's relevant for the Helm template, but not for Chart usage

## Issues

`n/a`.

## Type of change

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

`n/a`.

## Tests

Just CI, as changes are trivial.
