### PR TITLE
Skip non helm chart directory for release

### DIFF
--- a/.github/workflows/manual-release-charts.yaml
+++ b/.github/workflows/manual-release-charts.yaml
@@ -47,6 +47,7 @@ jobs:
           # update components
           for chart in ${SRC_DIR}/common/*
           do
+                  if [[ ! -f $chart/Chart.yaml ]]; then continue; fi
                   echo "Packaging chart $chart..."
                   helm dependency update ${chart}
                   helm package $chart --destination ${DEST_DIR}
@@ -57,7 +58,7 @@ jobs:
           for chart in ${SRC_DIR}/*
           do
                   if [ -f $chart ]; then continue; fi
-                  if [[ $chart =~ "common" ]]; then continue; fi
+                  if [[ ! -f $chart/Chart.yaml ]]; then continue; fi
                   echo "Packaging chart $chart..."
                   helm dependency update ${chart}
                   helm package $chart --destination ${DEST_DIR}


### PR DESCRIPTION
Some of the folders in helm-charts are not helm charts, skip them at release if there is no Chart.yaml file.

## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

See the failure of https://github.com/opea-project/GenAIInfra/actions/runs/13643535093/job/38138154683

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
