### PR TITLE
add LLM_MODEL_ID env to audioqna to set the correct model

### DIFF
--- a/helm-charts/audioqna/templates/deployment.yaml
+++ b/helm-charts/audioqna/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
               value: {{ include "tgi.fullname" (index .Subcharts "tgi") }}
             - name: LLM_SERVER_PORT
               value: "80"
+            - name: LLM_MODEL_ID
+              value: {{ .Values.tgi.LLM_MODEL_ID | quote }}
             - name: WHISPER_SERVER_HOST_IP
               value: {{ include "whisper.fullname" (index .Subcharts "whisper") }}
             - name: WHISPER_SERVER_PORT


### PR DESCRIPTION
## Description

The commit https://github.com/opea-project/GenAIExamples/commit/2dfcfa0436e8e44c536fa721e97142707f50d5b8 updated the LLM model param with real model name from env, we have to export the correct env from values file. 
Current helm chart only supports TGI, so this PR only exports env from TGI model. 

## Issues

Fixes #849 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## Dependencies

N/A

## Tests

Install helm chart from [source code](https://github.com/haoruan/opea-project-GenAIInfra/tree/main/helm-charts/audioqna)
