### PR TITLE
Add ChatQnA megaservice E2E (frontend) metric based autoscaling support

### DIFF
--- a/helm-charts/chatqna/hpa-e2e-values.yaml
+++ b/helm-charts/chatqna/hpa-e2e-values.yaml
@@ -1,0 +1,43 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Use application E2E metrics for HorizontalPodAutoscaler (HPA)
+#
+# Intended to be used together with:
+# - hpa-values.yaml
+# - gaudi-(vllm|tgi)-values.yaml
+#
+# NOTE: this should be used _only_ after one has manually found
+# suitable backend scaling factors that best match:
+# - selected frontend metric
+# - given service setup
+# - engine version (TGI, TEI, vLLM)
+# - used inference model
+# - inferencing options
+# - used acceleration device (CPU, Gaudi, Nvidia etc)
+# and updated those factors here.
+
+autoscaling:
+  useFrontendMetric: true
+  frontendMetricFactor: 256
+  frontendMetric: megaservice_request_pending
+
+# "frontendMetricFactor" is divider for (average) "frontendMetric" value,
+# to get replica count HPA will apply to given deployment
+
+vllm:
+  autoscaling:
+    useFrontendMetric: true
+    frontendMetricFactor: 128
+tgi:
+  autoscaling:
+    useFrontendMetric: true
+    frontendMetricFactor: 96
+teirerank:
+  autoscaling:
+    useFrontendMetric: true
+    frontendMetricFactor: 512
+tei:
+  autoscaling:
+    useFrontendMetric: true
+    frontendMetricFactor: 512

--- a/helm-charts/chatqna/templates/_helpers.tpl
+++ b/helm-charts/chatqna/templates/_helpers.tpl
@@ -62,3 +62,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create frontend custom metric name from chart name
+*/}}
+{{- define "chatqna.frontendMetricName" -}}
+{{- include "chatqna.fullname" . | replace "-" "_" | regexFind "[a-zA-Z_:][a-zA-Z0-9_:]*" }}_frontend_metric
+{{- end }}

--- a/helm-charts/chatqna/templates/custom-metrics-configmap.yaml
+++ b/helm-charts/chatqna/templates/custom-metrics-configmap.yaml
@@ -13,10 +13,31 @@ metadata:
 data:
   config.yaml: |
     rules:
-    {{- if and .Values.vllm.enabled .Values.vllm.autoscaling.enabled }}
-    # check metric with:
+    # check metrics with:
     # kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/default/service/*/<metric> | jq
+    {{- if .Values.autoscaling.useFrontendMetric }}
     #
+    # E2E metric for scaling both frontend (megaservice) and its backend services
+    #
+    - seriesQuery: '{__name__="{{ .Values.autoscaling.frontendMetric }}",service="{{ include "chatqna.fullname" . }}"}'
+      # sum of specified frontend metric for all deployed ChatQnA megaservice instances
+      metricsQuery: 'sum by (namespace,service)({{ .Values.autoscaling.frontendMetric }}{service="{{ include "chatqna.fullname" . }}",<<.LabelMatchers>>})'
+      name:
+        matches: ^{{ .Values.autoscaling.frontendMetric }}
+        as: "{{ include "chatqna.frontendMetricName" . }}"
+      resources:
+        # HPA needs both namespace + suitable object resource for its query paths:
+        # /apis/custom.metrics.k8s.io/v1beta1/namespaces/default/service/*/<metric>
+        # (pod is not suitable object type for matching as each instance has different name)
+        overrides:
+          namespace: {resource: "namespace"}
+          service:   {resource: "service"}
+    {{- end }}
+    #
+    # metrics for scaling backends based on their own metrics
+    #
+    {{- if and .Values.vllm.enabled .Values.vllm.autoscaling.enabled }}
+    # vLLM
     - seriesQuery: '{__name__="vllm:time_per_output_token_seconds_sum",service="{{ include "vllm.fullname" .Subcharts.vllm }}"}'
       # Average output token latency from vLLM histograms, over 1 min
       # (interval should be at least 4x serviceMonitor query interval,
@@ -26,14 +47,14 @@ data:
         matches: ^vllm:time_per_output_token_seconds_sum
         as: "{{ include "vllm.metricPrefix" .Subcharts.vllm }}_token_latency"
       resources:
-        # HPA needs both namespace + suitable object resource for its query paths:
-        # /apis/custom.metrics.k8s.io/v1beta1/namespaces/default/service/*/<metric>
-        # (pod is not suitable object type for matching as each instance has different name)
         overrides:
           namespace: {resource: "namespace"}
           service:   {resource: "service"}
     {{- end }}
     {{- if and .Values.tgi.enabled .Values.tgi.autoscaling.enabled }}
+    #
+    # TGI
+    #
     {{- if .Values.tgi.accelDevice }}
     - seriesQuery: '{__name__="tgi_queue_size",service="{{ include "tgi.fullname" .Subcharts.tgi }}"}'
       # TGI instances queue_size sum
@@ -55,6 +76,9 @@ data:
           service:   {resource: "service"}
     {{- end }}
     {{- if .Values.teirerank.autoscaling.enabled }}
+    #
+    # TEI-rerank
+    #
     {{- if .Values.teirerank.accelDevice }}
     - seriesQuery: '{__name__="te_queue_size",service="{{ include "teirerank.fullname" .Subcharts.teirerank }}"}'
       # TEI instances queue_size sum
@@ -76,6 +100,9 @@ data:
           service:   {resource: "service"}
     {{- end }}
     {{- if .Values.tei.autoscaling.enabled }}
+    #
+    # TEI-embed
+    #
     {{- if .Values.tei.accelDevice }}
     - seriesQuery: '{__name__="te_queue_size",service="{{ include "tei.fullname" .Subcharts.tei }}"}'
       # TEI instances queue_size sum

--- a/helm-charts/chatqna/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/chatqna/templates/horizontal-pod-autoscaler.yaml
@@ -2,15 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.global.monitoring .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.useFrontendMetric }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "tgi.fullname" . }}
+  name: {{ include "chatqna.fullname" . }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "tgi.fullname" . }}
+    name: {{ include "chatqna.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
@@ -20,8 +21,7 @@ spec:
         apiVersion: v1
         # get metric for named object of given type (in same namespace)
         kind: Service
-{{- if .Values.autoscaling.useFrontendMetric }}
-        name: {{ include "tgi.frontendService" . }}
+        name: {{ include "chatqna.fullname" . }}
       target:
         # Metric is sum from all pods. "AverageValue" divides value returned from
         # the custom metrics API by the number of Pods before comparing to the target:
@@ -30,25 +30,7 @@ spec:
         type: AverageValue
         averageValue: {{ .Values.autoscaling.frontendMetricFactor }}
       metric:
-        name: {{ include "tgi.frontendMetricName" . }}
-{{- else }}
-        name: {{ include "tgi.fullname" . }}
-      target:
-{{- if .Values.accelDevice }}
-        type: AverageValue
-        averageValue: 15
-      metric:
-        name: {{ include "tgi.metricPrefix" . }}_queue_size_sum
-{{- else }}
-        # Metric is average for all the pods. To avoid replica fluctuation when pod
-        # startup + request processing takes longer than HPA evaluation period, this uses
-        # "Value" (replicas = metric.value / target.value), instead of "AverageValue" type.
-        type: Value
-        value: 4 # seconds
-      metric:
-        name: {{ include "tgi.metricPrefix" . }}_request_latency
-{{- end }}
-{{- end }}
+        name: {{ include "chatqna.frontendMetricName" . }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 180
@@ -68,4 +50,5 @@ spec:
       #- type: Percent
       #  value: 25
       #  periodSeconds: 90
+{{- end }}
 {{- end }}

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -60,6 +60,14 @@ affinity: {}
 # (use hpa-values.yaml files to actually enable HPA).
 autoscaling:
   enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+  # useFrontendMetric changes scaling of all application services to be done
+  # based on application E2E metric and factors specified for each service,
+  # instead of each services' own metrics.
+  useFrontendMetric: false
+  frontendMetric: ""
+  frontendMetricFactor: 0
 
 # Optional subcharts enablement and subcharts settings overwritten
 # LLM choice, tgi by default.

--- a/helm-charts/common/tei/templates/_helpers.tpl
+++ b/helm-charts/common/tei/templates/_helpers.tpl
@@ -38,6 +38,20 @@ Convert chart name to a string suitable as metric prefix
 {{- end }}
 
 {{/*
+Frontend metric name for top-level application
+*/}}
+{{- define "tei.frontendMetricName" -}}
+{{- include "tei.metricPrefix" . | trimSuffix "_tei" }}_frontend_metric
+{{- end }}
+
+{{/*
+Frontend service name
+*/}}
+{{- define "tei.frontendService" -}}
+{{- include "tei.fullname" . | trimSuffix "-tei" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "tei.labels" -}}

--- a/helm-charts/common/tei/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/tei/templates/horizontal-pod-autoscaler.yaml
@@ -20,13 +20,21 @@ spec:
         apiVersion: v1
         # get metric for named object of given type (in same namespace)
         kind: Service
-        name: {{ include "tei.fullname" . }}
+{{- if .Values.autoscaling.useFrontendMetric }}
+        name: {{ include "tei.frontendService" . }}
       target:
-{{- if .Values.accelDevice }}
         # Metric is sum from all pods. "AverageValue" divides value returned from
         # the custom metrics API by the number of Pods before comparing to the target:
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
+        type: AverageValue
+        averageValue: {{ .Values.autoscaling.frontendMetricFactor }}
+      metric:
+        name: {{ include "tei.frontendMetricName" . }}
+{{- else }}
+        name: {{ include "tei.fullname" . }}
+      target:
+{{- if .Values.accelDevice }}
         type: AverageValue
         averageValue: 15
       metric:
@@ -39,6 +47,7 @@ spec:
         value: 4 # seconds
       metric:
         name: {{ include "tei.metricPrefix" . }}_request_latency
+{{- end }}
 {{- end }}
   behavior:
     scaleDown:

--- a/helm-charts/common/tei/values.yaml
+++ b/helm-charts/common/tei/values.yaml
@@ -12,9 +12,11 @@ replicaCount: 1
 # - Requires custom metrics ConfigMap available in the main application chart
 # - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  enabled: false
   minReplicas: 1
   maxReplicas: 2
-  enabled: false
+  useFrontendMetric: false
+  frontendMetricFactor: 0
 
 port: 2081
 shmSize: 1Gi

--- a/helm-charts/common/teirerank/templates/_helpers.tpl
+++ b/helm-charts/common/teirerank/templates/_helpers.tpl
@@ -38,6 +38,20 @@ Convert chart name to a string suitable as metric prefix
 {{- end }}
 
 {{/*
+Frontend metric name for top-level application
+*/}}
+{{- define "teirerank.frontendMetricName" -}}
+{{- include "teirerank.metricPrefix" . | trimSuffix "_teirerank" }}_frontend_metric
+{{- end }}
+
+{{/*
+Frontend service name
+*/}}
+{{- define "teirerank.frontendService" -}}
+{{- include "teirerank.fullname" . | trimSuffix "-teirerank" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "teirerank.labels" -}}

--- a/helm-charts/common/teirerank/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/teirerank/templates/horizontal-pod-autoscaler.yaml
@@ -20,13 +20,21 @@ spec:
         apiVersion: v1
         # get metric for named object of given type (in same namespace)
         kind: Service
-        name: {{ include "teirerank.fullname" . }}
+{{- if .Values.autoscaling.useFrontendMetric }}
+        name: {{ include "teirerank.frontendService" . }}
       target:
-{{- if .Values.accelDevice }}
         # Metric is sum from all pods. "AverageValue" divides value returned from
         # the custom metrics API by the number of Pods before comparing to the target:
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
+        type: AverageValue
+        averageValue: {{ .Values.autoscaling.frontendMetricFactor }}
+      metric:
+        name: {{ include "teirerank.frontendMetricName" . }}
+{{- else }}
+        name: {{ include "teirerank.fullname" . }}
+      target:
+{{- if .Values.accelDevice }}
         type: AverageValue
         averageValue: 15
       metric:
@@ -39,6 +47,7 @@ spec:
         value: 4 # seconds
       metric:
         name: {{ include "teirerank.metricPrefix" . }}_request_latency
+{{- end }}
 {{- end }}
   behavior:
     scaleDown:

--- a/helm-charts/common/teirerank/values.yaml
+++ b/helm-charts/common/teirerank/values.yaml
@@ -12,9 +12,11 @@ replicaCount: 1
 # - Requires custom metrics ConfigMap available in the main application chart
 # - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  enabled: false
   minReplicas: 1
   maxReplicas: 3
-  enabled: false
+  useFrontendMetric: false
+  frontendMetricFactor: 0
 
 port: 2082
 shmSize: 1Gi

--- a/helm-charts/common/tgi/templates/_helpers.tpl
+++ b/helm-charts/common/tgi/templates/_helpers.tpl
@@ -38,6 +38,20 @@ Convert chart name to a string suitable as metric prefix
 {{- end }}
 
 {{/*
+Frontend metric name for top-level application
+*/}}
+{{- define "tgi.frontendMetricName" -}}
+{{- include "tgi.metricPrefix" . | trimSuffix "_tgi" }}_frontend_metric
+{{- end }}
+
+{{/*
+Frontend service name
+*/}}
+{{- define "tgi.frontendService" -}}
+{{- include "tgi.fullname" . | trimSuffix "-tgi" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "tgi.labels" -}}

--- a/helm-charts/common/tgi/values.yaml
+++ b/helm-charts/common/tgi/values.yaml
@@ -12,9 +12,11 @@ replicaCount: 1
 # - Requires custom metrics ConfigMap available in the main application chart
 # - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  enabled: false
   minReplicas: 1
   maxReplicas: 4
-  enabled: false
+  useFrontendMetric: false
+  frontendMetricFactor: 0
 
 port: 2080
 shmSize: 1Gi

--- a/helm-charts/common/vllm/templates/_helpers.tpl
+++ b/helm-charts/common/vllm/templates/_helpers.tpl
@@ -38,6 +38,20 @@ Convert chart name to a string suitable as metric prefix
 {{- end }}
 
 {{/*
+Frontend metric name for top-level application
+*/}}
+{{- define "vllm.frontendMetricName" -}}
+{{- include "vllm.metricPrefix" . | trimSuffix "_vllm" }}_frontend_metric
+{{- end }}
+
+{{/*
+Frontend service name
+*/}}
+{{- define "vllm.frontendService" -}}
+{{- include "vllm.fullname" . | trimSuffix "-vllm" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "vllm.labels" -}}

--- a/helm-charts/common/vllm/templates/horizontal-pod-autoscaler.yaml
+++ b/helm-charts/common/vllm/templates/horizontal-pod-autoscaler.yaml
@@ -20,13 +20,22 @@ spec:
         apiVersion: v1
         # get metric for named object of given type (in same namespace)
         kind: Service
+{{- if .Values.autoscaling.useFrontendMetric }}
+        name: {{ include "vllm.frontendService" . }}
+{{- else }}
         name: {{ include "vllm.fullname" . }}
+{{- end }}
       target:
         # Metric is sum from all pods. "AverageValue" divides value returned from
         # the custom metrics API by the number of Pods before comparing to the target:
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
         #  https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
         type: AverageValue
+{{- if .Values.autoscaling.useFrontendMetric }}
+        averageValue: {{ .Values.autoscaling.frontendMetricFactor }}
+      metric:
+        name: {{ include "vllm.frontendMetricName" . }}
+{{- else }}
 {{- if .Values.accelDevice }}
         averageValue: 0.1
 {{- else }}
@@ -35,6 +44,7 @@ spec:
 {{- end }}
       metric:
         name: {{ include "vllm.metricPrefix" . }}_token_latency
+{{- end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 180

--- a/helm-charts/common/vllm/values.yaml
+++ b/helm-charts/common/vllm/values.yaml
@@ -12,9 +12,11 @@ replicaCount: 1
 # - Requires custom metrics ConfigMap available in the main application chart
 # - https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
+  enabled: false
   minReplicas: 1
   maxReplicas: 4
-  enabled: false
+  useFrontendMetric: false
+  frontendMetricFactor: 0
 
 # empty for CPU (longer latencies are tolerated before HPA scaling unaccelerated service)
 accelDevice: ""


### PR DESCRIPTION
## Description

- Add HPA scaling support also for ChatQnA megaservice/frontend service
- Add frontend metric based scaling option to all 5 HPA scaled components

Additional ChatQnA values file can be used to apply frontend metric based scaling to all HPA controlled components. It should be on top of the base HPA values file.

Custom metrics are provided for all components that have HPA enabled, even if they've been configured to use frontEndMetrics. That way user can easily change their scaling between frontend and backend metrics by re-installing Helm chart (because Prometheus-adapter custom metrics configMap does not change, its manual install step can be skipped).

## Issues

`n/a`.

## Type of change

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

Manual testing with this revealed issue with the E2E metric used for scaling, which needs to be fixed first: https://github.com/opea-project/GenAIComps/issues/1121

## Tests

Manual testing that HPA scaling works based on frontend metric.