### PR TITLE
vllm: Add securityContxt settings

### DIFF
--- a/helm-charts/agentqna/gaudi-values.yaml
+++ b/helm-charts/agentqna/gaudi-values.yaml
@@ -20,6 +20,9 @@ vllm:
   VLLM_SKIP_WARMUP: true
   shmSize: 16Gi
   extraCmdArgs: ["--tensor-parallel-size", "4", "--max-seq_len-to-capture", "16384", "--enable-auto-tool-choice", "--tool-call-parser", "llama3_json"]
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
 
 supervisor:
   llm_endpoint_url: http://{{ .Release.Name }}-vllm

--- a/helm-charts/chatqna/cpu-tgi-values.yaml
+++ b/helm-charts/chatqna/cpu-tgi-values.yaml
@@ -65,7 +65,7 @@ teirerank:
   # Potentially suitable values for scaling CPU TEI v1.5 with BAAI/bge-reranker-base model:
   resources:
     limits:
-      cpu: 4
+      cpu: 24
       memory: 30Gi
     requests:
       cpu: 2
@@ -91,7 +91,7 @@ tei:
   # Potentially suitable values for scaling CPU TEI 1.5 with BAAI/bge-base-en-v1.5 model:
   resources:
     limits:
-      cpu: 4
+      cpu: 24
       memory: 4Gi
     requests:
       cpu: 2

--- a/helm-charts/chatqna/gaudi-vllm-values.yaml
+++ b/helm-charts/chatqna/gaudi-vllm-values.yaml
@@ -15,16 +15,15 @@ vllm:
   resources:
     limits:
       habana.ai/gaudi: 1
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
   startupProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1
-    failureThreshold: 180
+    failureThreshold: 360
   readinessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-  livenessProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1

--- a/helm-charts/chatqna/guardrails-gaudi-values.yaml
+++ b/helm-charts/chatqna/guardrails-gaudi-values.yaml
@@ -87,16 +87,15 @@ vllm:
   resources:
     limits:
       habana.ai/gaudi: 1
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
   startupProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1
-    failureThreshold: 180
+    failureThreshold: 360
   readinessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-  livenessProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1

--- a/helm-charts/common/agent/gaudi-values.yaml
+++ b/helm-charts/common/agent/gaudi-values.yaml
@@ -20,4 +20,8 @@ vllm:
   PT_HPU_ENABLE_LAZY_COLLECTIVES: true
   VLLM_SKIP_WARMUP: true
   extraCmdArgs: ["--tensor-parallel-size", "4", "--max-seq_len-to-capture", "16384", "--enable-auto-tool-choice", "--tool-call-parser", "llama3_json"]
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
+
 llm_endpoint_url: http://{{ .Release.Name }}-vllm

--- a/helm-charts/common/llm-uservice/vllm-docsum-gaudi-values.yaml
+++ b/helm-charts/common/llm-uservice/vllm-docsum-gaudi-values.yaml
@@ -9,6 +9,7 @@ DOCSUM_BACKEND: "vLLM"
 LLM_MODEL_ID: "Intel/neural-chat-7b-v3-3"
 MAX_INPUT_TOKENS: 2048
 MAX_TOTAL_TOKENS: 4096
+retryTimeoutSeconds: 720
 
 
 tgi:
@@ -24,3 +25,8 @@ vllm:
   resources:
     limits:
       habana.ai/gaudi: 1
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
+  startupProbe:
+    failureThreshold: 360

--- a/helm-charts/common/llm-uservice/vllm-gaudi-values.yaml
+++ b/helm-charts/common/llm-uservice/vllm-gaudi-values.yaml
@@ -17,6 +17,12 @@ vllm:
   resources:
     limits:
       habana.ai/gaudi: 1
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
+  startupProbe:
+    failureThreshold: 360
 
 TEXTGEN_BACKEND: "vLLM"
 LLM_MODEL_ID: Intel/neural-chat-7b-v3-3
+retryTimeoutSeconds: 720

--- a/helm-charts/common/vllm/gaudi-values.yaml
+++ b/helm-charts/common/vllm/gaudi-values.yaml
@@ -12,3 +12,11 @@ extraCmdArgs: ["--tensor-parallel-size","1","--block-size","128","--max-num-seqs
 resources:
   limits:
     habana.ai/gaudi: 1
+
+# NOTE: opea/vllm-gaudi image requires running as root during runtime
+securityContext:
+  runAsUser: 0
+  runAsNonRoot: false
+# NOTE: opea/vllm-gaudi needsd more warm up time
+startupProbe:
+  failureThreshold: 360

--- a/helm-charts/common/vllm/templates/configmap.yaml
+++ b/helm-charts/common/vllm/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   {{- end }}
   NUMBA_CACHE_DIR: "/tmp"
   HF_HOME: "/tmp/.cache/huggingface"
+  XDG_CONFIG_HOME: "/tmp"
   # https://github.com/outlines-dev/outlines/blob/main/outlines/caching.py#L14-L29
   OUTLINES_CACHE_DIR: "/tmp/.cache/outlines"
   {{- if .Values.VLLM_CPU_KVCACHE_SPACE }}

--- a/helm-charts/common/vllm/templates/deployment.yaml
+++ b/helm-charts/common/vllm/templates/deployment.yaml
@@ -57,7 +57,10 @@ spec:
               echo "Download model {{ .Values.LLM_MODEL_ID }} ... ";
               huggingface-cli download --cache-dir /data {{ .Values.LLM_MODEL_ID | quote }};
               echo "Change model files mode ...";
-              chmod -R g+w /data/models--{{ replace "/" "--" .Values.LLM_MODEL_ID }}
+              chmod -R g+w /data/models--{{ replace "/" "--" .Values.LLM_MODEL_ID }};
+              # Some models(e.g. mistralai/Mistral-7B-Instruct-v0.3, etc) need to write additional files to /data root directory
+              chmod -R g+w /data;
+              chmod -R g+w $(HF_HOME);
               # NOTE: Buggy logout command;
               # huggingface-cli logout;
           volumeMounts:

--- a/helm-charts/common/vllm/values.yaml
+++ b/helm-charts/common/vllm/values.yaml
@@ -48,25 +48,21 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-#  readOnlyRootFilesystem: true
-#  allowPrivilegeEscalation: false
-#  runAsNonRoot: true
-#  runAsUser: 1000
-#  capabilities:
-#    drop:
-#    - ALL
-#  seccompProfile:
-#    type: RuntimeDefault
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
 
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -76,13 +72,6 @@ resources:
 
 extraCmdArgs: []
 
-livenessProbe:
-  httpGet:
-    path: /health
-    port: http
-  initialDelaySeconds: 5
-  periodSeconds: 5
-  failureThreshold: 24
 readinessProbe:
   httpGet:
     path: /health

--- a/helm-charts/docsum/gaudi-vllm-values.yaml
+++ b/helm-charts/docsum/gaudi-vllm-values.yaml
@@ -9,6 +9,7 @@ tgi:
 
 llm-uservice:
   DOCSUM_BACKEND: "vLLM"
+  retryTimeoutSeconds: 720
 
 vllm:
   enabled: true
@@ -18,16 +19,15 @@ vllm:
   resources:
     limits:
       habana.ai/gaudi: 1
+  securityContext:
+    runAsUser: 0
+    runAsNonRoot: false
   startupProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1
-    failureThreshold: 120
+    failureThreshold: 360
   readinessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-  livenessProbe:
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1


### PR DESCRIPTION
## Description

1. Add securityContext settings for image of opea/vllm and opea/vllm-gaudi.
2. Increase cpu limits settings for tei/teirerank since ingesting pdf files requires more cpu times to avoid request failure due to
embedding/reranking service unresponsiveness.


## Issues

Related to issue #815

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
