### PR TITLE
codetrans: add vLLM as default inference engine

### DIFF
--- a/helm-charts/codetrans/Chart.yaml
+++ b/helm-charts/codetrans/Chart.yaml
@@ -9,6 +9,11 @@ dependencies:
   - name: tgi
     version: 0-latest
     repository: "file://../common/tgi"
+    condition: tgi.enabled
+  - name: vllm
+    version: 0-latest
+    repository: "file://../common/vllm"
+    condition: vllm.enabled
   - name: llm-uservice
     version: 0-latest
     repository: "file://../common/llm-uservice"

--- a/helm-charts/codetrans/README.md
+++ b/helm-charts/codetrans/README.md
@@ -15,9 +15,14 @@ helm dependency update codetrans
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"
 export MODELNAME="mistralai/Mistral-7B-Instruct-v0.3"
-helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME}
-# To use Gaudi device
-# helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --values codetrans/gaudi-values.yaml
+# To use CPU with vLLM
+helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservcie.LLM_MODEL_ID=${MODELNAME} --set vllm.LLM_MODEL_ID=${MODELNAME} -f cpu-values.yaml
+# To use CPU with TGI
+# helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservcie.LLM_MODEL_ID=${MODELNAME} --set tgi.LLM_MODEL_ID=${MODELNAME} -f cpu-tgi-values.yaml
+# To use Gaudi device with vLLM
+# helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservcie.LLM_MODEL_ID=${MODELNAME} --set vllm.LLM_MODEL_ID=${MODELNAME} -f gaudi-values.yaml
+# To use Gaudi device with TGI
+# helm install codetrans codetrans --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set llm-uservcie.LLM_MODEL_ID=${MODELNAME} --set tgi.LLM_MODEL_ID=${MODELNAME} -f gaudi-tgi-values.yaml
 ```
 
 ### IMPORTANT NOTE

--- a/helm-charts/codetrans/cpu-tgi-values.yaml
+++ b/helm-charts/codetrans/cpu-tgi-values.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tgi:
-  enabled: false
-vllm:
   enabled: true
+vllm:
+  enabled: false
 llm-uservice:
-  TEXTGEN_BACKEND: vLLM
+  TEXTGEN_BACKEND: TGI

--- a/helm-charts/codetrans/gaudi-tgi-values.yaml
+++ b/helm-charts/codetrans/gaudi-tgi-values.yaml
@@ -1,0 +1,37 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+tgi:
+  enabled: true
+  accelDevice: "gaudi"
+  image:
+    repository: ghcr.io/huggingface/tgi-gaudi
+    tag: "2.3.1"
+  resources:
+    limits:
+      habana.ai/gaudi: 1
+  MAX_INPUT_LENGTH: "2048"
+  MAX_TOTAL_TOKENS: "4096"
+  CUDA_GRAPHS: ""
+  OMPI_MCA_btl_vader_single_copy_mechanism: "none"
+  ENABLE_HPU_GRAPH: "true"
+  LIMIT_HPU_GRAPH: "true"
+  USE_FLASH_ATTENTION: "true"
+  FLASH_ATTENTION_RECOMPUTE: "true"
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+  startupProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 120
+vllm:
+  enabled: false
+llm-uservice:
+  TEXTGEN_BACKEND: TGI

--- a/helm-charts/codetrans/gaudi-values.yaml
+++ b/helm-charts/codetrans/gaudi-values.yaml
@@ -1,32 +1,33 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# Accelerate inferencing in heaviest components to improve performance
+# by overriding their subchart values
+
 tgi:
+  enabled: false
+
+vllm:
+  enabled: true
   accelDevice: "gaudi"
   image:
-    repository: ghcr.io/huggingface/tgi-gaudi
-    tag: "2.3.1"
+    repository: opea/vllm-gaudi
+  startupProbe:
+    failureThreshold: 360
+
+  PT_HPU_ENABLE_LAZY_COLLECTIVES: "true"
+  OMPI_MCA_btl_vader_single_copy_mechanism: "none"
+
   resources:
     limits:
       habana.ai/gaudi: 1
-  MAX_INPUT_LENGTH: "1024"
-  MAX_TOTAL_TOKENS: "2048"
-  CUDA_GRAPHS: ""
-  OMPI_MCA_btl_vader_single_copy_mechanism: "none"
-  ENABLE_HPU_GRAPH: "true"
-  LIMIT_HPU_GRAPH: "true"
-  USE_FLASH_ATTENTION: "true"
-  FLASH_ATTENTION_RECOMPUTE: "true"
-  livenessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-  readinessProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-  startupProbe:
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-    failureThreshold: 120
+  extraCmdArgs: [
+    "--tensor-parallel-size", "1",
+    "--block-size", "128",
+    "--max-num-seqs", "256",
+    "--max-seq_len-to-capture", "2048"
+  ]
+
+llm-uservice:
+  TEXTGEN_BACKEND: vLLM
+  retryTimeoutSeconds: 720

--- a/helm-charts/codetrans/values.yaml
+++ b/helm-charts/codetrans/values.yaml
@@ -59,9 +59,15 @@ affinity: {}
 
 # To override values in subchart tgi
 tgi:
+  enabled: false
+  LLM_MODEL_ID: mistralai/Mistral-7B-Instruct-v0.3
+
+vllm:
+  enabled: true
   LLM_MODEL_ID: mistralai/Mistral-7B-Instruct-v0.3
 
 llm-uservice:
+  TEXTGEN_BACKEND: vLLM
   LLM_MODEL_ID: mistralai/Mistral-7B-Instruct-v0.3
 
 nginx:

--- a/helm-charts/valuefiles.yaml
+++ b/helm-charts/valuefiles.yaml
@@ -53,7 +53,9 @@ codetrans:
   dest_dir: CodeTrans/kubernetes/helm
   values:
     - cpu-values.yaml
+    - cpu-tgi-values.yaml
     - gaudi-values.yaml
+    - gaudi-tgi-values.yaml
 docsum:
   src_repo: GenAIInfra
   src_dir: helm-charts/docsum


### PR DESCRIPTION
## Description

codetrans: add vLLM as default inference engine

## Issues

Fixes #858

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

CI on xeon, manually on Gaudi
