### PR TITLE
codegen: limit max output token in test case

### DIFF
--- a/helm-charts/codegen/templates/tests/test-pod.yaml
+++ b/helm-charts/codegen/templates/tests/test-pod.yaml
@@ -20,7 +20,7 @@ spec:
           max_retry=20;
           for ((i=1; i<=max_retry; i++)); do
             curl http://{{ include "codegen.fullname" . }}:{{ .Values.service.port }}/v1/codegen -sS --fail-with-body \
-            -d '{"messages": "Implement a high-level API for a TODO list application. The API takes as input an operation request and updates the TODO list in place. If the request is invalid, raise an exception."}' \
+            -d '{"messages": "Implement a high-level API for a TODO list application. The API takes as input an operation request and updates the TODO list in place. If the request is invalid, raise an exception.", "max_tokens": 256}' \
             -H 'Content-Type: application/json' && break;
             curlcode=$?
             if [[ $curlcode -eq 7 ]]; then sleep 10; else echo "curl failed with code $curlcode"; exit 1; fi;


### PR DESCRIPTION
## Description

To avoid CI timeout in busy environment, we need to put limit on max_tokens.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
