### PR TITLE
Typo fix on main.tf

### DIFF
--- a/cloud-service-provider/aws/eks/terraform/main.tf
+++ b/cloud-service-provider/aws/eks/terraform/main.tf
@@ -158,7 +158,7 @@ resource "kubernetes_storage_class_v1" "eks_efs" {
   reclaim_policy      = "Retain"
   parameters = {
     provisioningMode = "efs-ap"
-    fileSystemId: "${module.efs.id}"
+    fileSystemId = "${module.efs.id}"
     directoryPerms = "700"
   }
   depends_on = [ 


### PR DESCRIPTION
Typo fix

## Description

Typo fixes for ":" to "=" in the Terraform template. This error caused the example to fail because it couldn't correctly create the PVC, and the pods, depending on that, were failing to launch.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

