### PR TITLE
kubeai: add llama-3.3-70b-instruct model for Gaudi

### DIFF
--- a/kubeai/models/llama-3.3-70b-instruct-gaudi.yaml
+++ b/kubeai/models/llama-3.3-70b-instruct-gaudi.yaml
@@ -1,0 +1,23 @@
+# Source: models/templates/models.yaml
+apiVersion: kubeai.org/v1
+kind: Model
+metadata:
+  name: llama-3.3-70b-instruct-gaudi
+spec:
+  features: [TextGeneration]
+  url: hf://meta-llama/Llama-3.3-70B-Instruct
+  cacheProfile: nfs
+  engine: VLLM
+  args:
+    - --tensor-parallel-size=4
+    - --max-seq_len-to-capture=16384
+    - --enable-auto-tool-choice
+    - --tool-call-parser=llama3_json
+  env:
+    OMPI_MCA_btl_vader_single_copy_mechanism: none
+    PT_HPU_ENABLE_LAZY_COLLECTIVES: "true"
+    VLLM_SKIP_WARMUP: "true"
+
+  minReplicas: 1
+  maxReplicas: 2
+  resourceProfile: gaudi-for-text-generation:4

--- a/kubeai/models/llama-3.3-70b-instruct-gaudi.yaml
+++ b/kubeai/models/llama-3.3-70b-instruct-gaudi.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # Source: models/templates/models.yaml
 apiVersion: kubeai.org/v1
 kind: Model


### PR DESCRIPTION
## Description

Add llama-3.3-70b-instruct model for Gaudi with resource profile and vLLM args/env to KubeAI.

## Issues

(https://github.com/opea-project/GenAIInfra/issues/833)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`

## Tests

Manually tested with [llmperf](https://github.com/ray-project/llmperf).
