### PR TITLE
Remove chat-template

### DIFF
--- a/helm-charts/common/lvm-uservice/values.yaml
+++ b/helm-charts/common/lvm-uservice/values.yaml
@@ -111,7 +111,6 @@ global:
 vllm:
   enabled: false
   LLM_MODEL_ID: llava-hf/llava-v1.6-mistral-7b-hf
-  extraCmdArgs: ["--chat-template", "examples/template_llava.jinja"]
 tgi:
   enabled: false
   LLM_MODEL_ID: llava-hf/llava-v1.6-mistral-7b-hf


### PR DESCRIPTION
New opea/vllm image doesn‘t have the chat template included. Same change as https://github.com/opea-project/GenAIExamples/pull/1831

## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

Fix the helm chart part of component lvm https://github.com/opea-project/GenAIComps/issues/1589

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
