### PR TITLE
chatqna: integrate ollama llm k8s support

### DIFF
--- a/helm-charts/chatqna/Chart.yaml
+++ b/helm-charts/chatqna/Chart.yaml
@@ -31,6 +31,10 @@ dependencies:
     version: 0-latest
     repository: "file://../common/llm-uservice"
     condition: llm-uservice.enabled
+  - name: ollama
+    version: 0-latest
+    repository: "file://../common/ollama"
+    condition: ollama.enabled
   - name: tei
     version: 0-latest
     repository: "file://../common/tei"

--- a/helm-charts/chatqna/README.md
+++ b/helm-charts/chatqna/README.md
@@ -34,6 +34,8 @@ helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --
 #helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} -f chatqna/gaudi-tgi-values.yaml
 # To use Nvidia GPU with TGI
 #helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set tgi.LLM_MODEL_ID=${MODELNAME} -f chatqna/nv-values.yaml
+# To use CPU with Ollama
+#helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set ollama.LLM_MODEL_ID=${MODELNAME} -f chatqna/cpu-ollama-values.yaml
 # To include guardrail component in chatqna on Gaudi with vLLM
 #helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} -f chatqna/guardrails-gaudi-values.yaml
 # To run chatqna with Intel TDX feature

--- a/helm-charts/chatqna/cpu-ollama-values.yaml
+++ b/helm-charts/chatqna/cpu-ollama-values.yaml
@@ -1,0 +1,11 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+vllm:
+  enabled: false
+tgi:
+  enabled: false
+ollama:
+  enabled: true
+  repository: ollama/ollama
+  tag: "0.5.7"

--- a/helm-charts/chatqna/templates/deployment.yaml
+++ b/helm-charts/chatqna/templates/deployment.yaml
@@ -39,19 +39,27 @@ spec:
               {{- if eq .Values.CHATQNA_TYPE "CHATQNA_FAQGEN"}}
               value: {{ .Release.Name }}-llm-uservice
               {{- else }}
+              {{- if .Values.ollama.enabled }}
+              value: {{ .Release.Name }}-ollama
+              {{- else }}
               {{- if .Values.vllm.enabled }}
               value: {{ .Release.Name }}-vllm
               {{- else }}
               value: {{ .Release.Name }}-tgi
               {{- end }}
               {{- end }}
+              {{- end }}
             - name: LLM_SERVER_PORT
               value: "80"
             - name: LLM_MODEL
+              {{- if .Values.ollama.enabled }}
+              value: {{ .Values.ollama.LLM_MODEL_ID | quote }}
+              {{- else }}
               {{- if .Values.vllm.enabled }}
               value: {{ .Values.vllm.LLM_MODEL_ID | quote }}
               {{- else }}
               value: {{ .Values.tgi.LLM_MODEL_ID | quote }}
+              {{- end }}
               {{- end }}
             - name: RERANK_SERVER_HOST_IP
               value: {{ .Release.Name }}-teirerank

--- a/helm-charts/chatqna/templates/deployment.yaml
+++ b/helm-charts/chatqna/templates/deployment.yaml
@@ -38,28 +38,22 @@ spec:
               # For FaqGen, llm-uservice is used.
               {{- if eq .Values.CHATQNA_TYPE "CHATQNA_FAQGEN"}}
               value: {{ .Release.Name }}-llm-uservice
-              {{- else }}
-              {{- if .Values.ollama.enabled }}
+              {{- else if .Values.ollama.enabled }}
               value: {{ .Release.Name }}-ollama
-              {{- else }}
-              {{- if .Values.vllm.enabled }}
+              {{- else if .Values.vllm.enabled }}
               value: {{ .Release.Name }}-vllm
               {{- else }}
               value: {{ .Release.Name }}-tgi
-              {{- end }}
-              {{- end }}
               {{- end }}
             - name: LLM_SERVER_PORT
               value: "80"
             - name: LLM_MODEL
               {{- if .Values.ollama.enabled }}
               value: {{ .Values.ollama.LLM_MODEL_ID | quote }}
-              {{- else }}
-              {{- if .Values.vllm.enabled }}
+              {{- else if .Values.vllm.enabled }}
               value: {{ .Values.vllm.LLM_MODEL_ID | quote }}
               {{- else }}
               value: {{ .Values.tgi.LLM_MODEL_ID | quote }}
-              {{- end }}
               {{- end }}
             - name: RERANK_SERVER_HOST_IP
               value: {{ .Release.Name }}-teirerank

--- a/helm-charts/chatqna/values.yaml
+++ b/helm-charts/chatqna/values.yaml
@@ -66,6 +66,9 @@ autoscaling:
 tgi:
   enabled: false
   LLM_MODEL_ID: meta-llama/Meta-Llama-3-8B-Instruct
+ollama:
+  enabled: false
+  LLM_MODEL_ID: llama3.2:1b
 vllm:
   enabled: true
   LLM_MODEL_ID: meta-llama/Meta-Llama-3-8B-Instruct


### PR DESCRIPTION
## Description

This integrates the existing ollama component into the ChatQnA RAG so it can be used with with helm/k8s. I'm working on a blog post for Canonical (the company behind Ubuntu) highlighting OPEA that will make use of this feature.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds new functionality)

## Dependencies

None

## Tests

I successfully tested the following on my Dell XPS13 laptop (32 GiB RAM) running Ubuntu 24.04 with Canonical Kubernetes:

```bash
helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} -f chatqna/cpu-ollama-values.yaml
```

```bash
helm install chatqna chatqna --set global.HUGGINGFACEHUB_API_TOKEN=${HFTOKEN} --set global.modelUseHostPath=${MODELDIR} --set ollama.LLM_MODEL_ID=${MODELNAME} -f chatqna/cpu-ollama-values.yaml
```

* Verified the correct Ollama model was running (by inspecting the Ollama pod logs) in the two cases above 
* Verified the nginx Web UI works
* Verified I could query the `/generate` Ollama server endpoint directly
