### PR TITLE
Move Helm chart helper scripts to scripts/ subdir

### DIFF
--- a/.github/workflows/_helm-e2e.yaml
+++ b/.github/workflows/_helm-e2e.yaml
@@ -112,7 +112,7 @@ jobs:
             echo "should_cleanup=false" >> $GITHUB_ENV
             exit 0
           fi
-          helm-charts/update_dependency.sh && helm dependency update ${{ env.CHART_FOLDER }}
+          helm-charts/scripts/update_dependency.sh && helm dependency update ${{ env.CHART_FOLDER }}
           for img in `helm template -n $NAMESPACE -f ${{ env.CHART_FOLDER }}/${value_file} $RELEASE_NAME ${{ env.CHART_FOLDER }} | grep 'image:' | grep 'opea/' | awk '{print $2}' | xargs`;
           do
             if ! .github/workflows/scripts/e2e/chart_test.sh check_local_opea_image "$img"; then

--- a/.github/workflows/manual-freeze-tag.yaml
+++ b/.github/workflows/manual-freeze-tag.yaml
@@ -51,7 +51,7 @@ jobs:
           find microservices-connector/helm/ -name 'Chart.yaml' -type f -exec sed -i "s#version: ${{ inputs.oldversion }}#version: ${{ inputs.newversion }}#g" {} \;
           sed -i "s|opea/gmcrouter:latest|opea/gmcrouter:$NEWTAG|g" microservices-connector/config/gmcrouter/gmc-router.yaml
           sed -i "s|opea/gmcmanager:latest|opea/gmcmanager:$NEWTAG|g" microservices-connector/config/manager/gmc-manager.yaml
-          ./helm-charts/update_manifests.sh
+          helm-charts/scripts/update_manifests.sh
 
       - name: Commit changes
         run: |

--- a/.github/workflows/manual-release-charts.yaml
+++ b/.github/workflows/manual-release-charts.yaml
@@ -44,7 +44,7 @@ jobs:
           fi
           mkdir -p ${DEST_DIR}
           # Update dependency for components first
-          ${SRC_DIR}/update_dependency.sh
+          ${SRC_DIR}/scripts/update_dependency.sh
           # update components
           for chart in ${SRC_DIR}/common/*
           do

--- a/.github/workflows/pr-chart-validate.yaml
+++ b/.github/workflows/pr-chart-validate.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm-charts/update_dependency.sh
+          helm-charts/scripts/update_dependency.sh
           exclude_param=""
           for libchart in `find helm-charts/ -name "Chart.yaml" | xargs grep -rl '^type:.*library' | xargs grep '^name:' | awk '{print $2}' `
           do

--- a/.github/workflows/pr-path-detection.yml
+++ b/.github/workflows/pr-path-detection.yml
@@ -28,19 +28,21 @@ jobs:
           changed_files="$(git diff --name-status --diff-filter=ARM ${{ github.event.pull_request.base.sha }} ${merged_commit} | awk '/\.md$/ {print $NF}')"
           if  [ -n "$changed_files" ]; then
             for changed_file in $changed_files; do
+              echo "URL checks for: $changed_file"
               url_lines=$(grep -H -Eo '\]\(http[s]?://[^)]+\)' "$changed_file" | grep -Ev 'GenAIEval/blob/main') || true
               if [ -n "$url_lines" ]; then
                 for url_line in $url_lines; do
                   url=$(echo "$url_line"|cut -d '(' -f2 | cut -d ')' -f1|sed 's/\.git$//')
                   path=$(echo "$url_line"|cut -d':' -f1 | cut -d'/' -f2-)
+                  echo "- $url"
                   response=$(curl -L -s -o /dev/null -w "%{http_code}" "$url")
                   if [ "$response" -ne 200 ]; then
-                    echo "**********Validation failed, try again**********"
+                    echo "**********Validation failed ($response), try again**********"
                     response_retry=$(curl -s -o /dev/null -w "%{http_code}" "$url")
                     if [ "$response_retry" -eq 200 ]; then
                       echo "*****Retry successful*****"
                     else
-                      echo "Invalid link from ${{github.workspace}}/$path: $url"
+                      echo "Invalid link ($response_retry) from ${{github.workspace}}/$path: $url"
                       fail="TRUE"
                     fi
                   fi
@@ -48,14 +50,13 @@ jobs:
               fi
             done
           else
-            echo "No changed .md file."
+            echo "No changed .md file(s)."
           fi
 
           if [[ "$fail" == "TRUE" ]]; then
             exit 1
-          else
-            echo "All hyperlinks are valid."
           fi
+          echo "All hyperlinks are valid."
         shell: bash
 
   check-the-validity-of-relative-path:

--- a/.github/workflows/pr-path-detection.yml
+++ b/.github/workflows/pr-path-detection.yml
@@ -31,7 +31,7 @@ jobs:
           if  [ -n "$changed_files" ]; then
             for changed_file in $changed_files; do
               echo "URL checks for: $changed_file"
-              url_lines=$(grep -H -Eo '\]\(http[s]?://[^)]+\)' "$changed_file" | grep -Ev 'GenAIEval/blob/main') || true
+              url_lines=$(grep -H -Eo '\]\(http[s]?://[^)]+\)' "$changed_file" | sort -u | grep -Ev 'GenAIEval/blob/main') || true
               if [ -n "$url_lines" ]; then
                 for url_line in $url_lines; do
                   url=$(echo "$url_line"|cut -d '(' -f2 | cut -d ')' -f1|sed 's/\.git$//')

--- a/.github/workflows/pr-path-detection.yml
+++ b/.github/workflows/pr-path-detection.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Check the Validity of Hyperlinks
         run: |
           cd ${{github.workspace}}
+          delay=15   # minimum consecutive URL request delay to pass Fortinet Proxy checks
+          timeout=15 # max connect timeout
           fail="FALSE"
           merged_commit=$(git log -1 --format='%H')
           changed_files="$(git diff --name-status --diff-filter=ARM ${{ github.event.pull_request.base.sha }} ${merged_commit} | awk '/\.md$/ {print $NF}')"
@@ -35,10 +37,11 @@ jobs:
                   url=$(echo "$url_line"|cut -d '(' -f2 | cut -d ')' -f1|sed 's/\.git$//')
                   path=$(echo "$url_line"|cut -d':' -f1 | cut -d'/' -f2-)
                   echo "- $url"
-                  response=$(curl -L -s -o /dev/null -w "%{http_code}" "$url")
+                  sleep $delay
+                  response=$(curl --connect-timeout $timeout -L -s -o /dev/null -w "%{http_code}" "$url")
                   if [ "$response" -ne 200 ]; then
                     echo "**********Validation failed ($response), try again**********"
-                    response_retry=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+                    response_retry=$(curl --connect-timeout $timeout -s -o /dev/null -w "%{http_code}" "$url")
                     if [ "$response_retry" -eq 200 ]; then
                       echo "*****Retry successful*****"
                     else

--- a/.github/workflows/push-release-charts.yaml
+++ b/.github/workflows/push-release-charts.yaml
@@ -73,7 +73,7 @@ jobs:
             done
           }
           # Update dependency for components first
-          ${CHARTS_DIR}/update_dependency.sh
+          ${CHARTS_DIR}/scripts/update_dependency.sh
           # Update components: exclude other Helm chart docs than README.md
           update_charts "$CHARTS_DIR/common/" 3 '.*/[^R][^/]*\.md$'
           # Update Examples: exclude non-helm subdirs, files not in subdirs, other docs

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -170,7 +170,7 @@ find . -name '*values.yaml' -type f -exec sed -i "s#repository: opea/*#repositor
 ## Generate manifests from Helm Charts
 
 Some users may want to use Kubernetes manifests (YAML files) for workload deployment, we do not maintain manifests itself, and will generate them using `helm template`.
-See `update_genaiexamples.sh` for how the manifests are generated for supported _GenAIExamples_.
-See `update_manifests.sh` for how the manifests are generated for supported _GenAIComps_.
+See `scripts/update_genaiexamples.sh` for how the manifests are generated for supported _GenAIExamples_.
+See `scripts/update_manifests.sh` for how the manifests are generated for supported _GenAIComps_.
 Please note that the above scripts have hardcoded settings to reduce user configuration effort.
 They are not supposed to be directly used by users.

--- a/helm-charts/TDX.md
+++ b/helm-charts/TDX.md
@@ -76,7 +76,7 @@ Follow the steps below to deploy ChatQnA:
    export MODELNAME="Intel/neural-chat-7b-v3-3"
    export myrelease=chatqna
    export chartname=chatqna
-   ./update_dependency.sh
+   scripts/update_dependency.sh
    helm dependency update $chartname
    ```
 

--- a/helm-charts/audioqna/README.md
+++ b/helm-charts/audioqna/README.md
@@ -17,7 +17,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update audioqna
 export HFTOKEN="insert-your-huggingface-token-here"
 # To use CPU with vLLM

--- a/helm-charts/chatqna/README.md
+++ b/helm-charts/chatqna/README.md
@@ -19,7 +19,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update chatqna
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"

--- a/helm-charts/codegen/README.md
+++ b/helm-charts/codegen/README.md
@@ -17,7 +17,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update codegen
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"

--- a/helm-charts/codetrans/README.md
+++ b/helm-charts/codetrans/README.md
@@ -10,7 +10,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update codetrans
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"

--- a/helm-charts/docsum/README.md
+++ b/helm-charts/docsum/README.md
@@ -12,7 +12,7 @@ To install the chart, run the following:
 git clone https://github.com/opea-project/GenAIInfra.git
 cd GenAIInfra/helm-charts/
 mkdir /mnt/opea-models && chmod -R 664 /mnt/opea-models
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update docsum
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"

--- a/helm-charts/scripts/check_values.sh
+++ b/helm-charts/scripts/check_values.sh
@@ -4,6 +4,9 @@
 
 #set -xe
 
+CHARTS_DIR=$(cd $(dirname "$0")/.. && pwd)
+configfile=$CHARTS_DIR/valuefiles.yaml
+
 function check_chart {
   chart=$1
   valuefiles=$(yq eval ".$chart.values" $configfile |sed 's/^- //')
@@ -29,9 +32,7 @@ function check_chart {
   done
 }
 
-configfile=valuefiles.yaml
-
-charts_list=${1:-$(cat valuefiles.yaml |grep -v "^#" |grep -v "^  " |grep -v "^$" |sed 's/:/ /')}
+charts_list=${1:-$(cat $configfile |grep -v "^#" |grep -v "^  " |grep -v "^$" |sed 's/:/ /')}
 
 echo $charts_list
 mkdir -p tmp

--- a/helm-charts/scripts/update_dependency.sh
+++ b/helm-charts/scripts/update_dependency.sh
@@ -2,8 +2,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-UPD_DIR=$(cd $(dirname "$0") && pwd)
-for chart in ${UPD_DIR}/common/*
+CHARTS_DIR=$(cd $(dirname "$0")/.. && pwd)
+for chart in ${CHARTS_DIR}/common/*
 do
 	echo "Update dependency for `basename $chart`..."
         rm -f ${chart}/Chart.lock

--- a/helm-charts/scripts/update_genaiexamples.sh
+++ b/helm-charts/scripts/update_genaiexamples.sh
@@ -5,10 +5,10 @@
 
 set -e
 
-CUR_DIR=$(cd $(dirname "$0") && pwd)
+CHARTS_DIR=$(cd $(dirname "$0")/.. && pwd)
 MODELPATH="/mnt/opea-models"
 
-GENAIEXAMPLEDIR=${CUR_DIR}/../../GenAIExamples
+GENAIEXAMPLEDIR=${CHARTS_DIR}/../../GenAIExamples
 
 if [ "f$1" != "f" ]; then
 	GENAIEXAMPLEDIR=$1
@@ -41,8 +41,8 @@ function generate_yaml {
 }
 
 
-${CUR_DIR}/update_dependency.sh
-pushd ${CUR_DIR}
+${CHARTS_DIR}/scripts/update_dependency.sh
+pushd ${CHARTS_DIR}
 generate_yaml chatqna 	values.yaml	 		ChatQnA/kubernetes/manifests/xeon	chatqna.yaml
 generate_yaml chatqna 	guardrails-values.yaml	 	ChatQnA/kubernetes/manifests/xeon	chatqna-guardrails.yaml
 generate_yaml chatqna 	gaudi-values.yaml 		ChatQnA/kubernetes/manifests/gaudi	chatqna.yaml

--- a/helm-charts/scripts/update_manifests.sh
+++ b/helm-charts/scripts/update_manifests.sh
@@ -3,8 +3,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-CUR_DIR=$(cd $(dirname "$0") && pwd)
-OUTPUTDIR=${CUR_DIR}/../microservices-connector/config/manifests
+CHARTS_DIR=$(cd $(dirname "$0")/.. && pwd)
+OUTPUTDIR=${CHARTS_DIR}/../microservices-connector/config/manifests
 MODELPATH="/mnt/opea-models"
 
 NEWTAG="${NEWTAG:-latest}"
@@ -45,9 +45,9 @@ function generate_yaml {
 }
 
 mkdir -p $OUTPUTDIR
-${CUR_DIR}/update_dependency.sh
-cd $CUR_DIR
-for chart in ${CUR_DIR}/common/*
+${CHARTS_DIR}/scripts/update_dependency.sh
+cd $CHARTS_DIR
+for chart in ${CHARTS_DIR}/common/*
 do
 	chartname=`basename $chart`
 	echo "Update manifest for $chartname..."

--- a/helm-charts/searchqna/README.md
+++ b/helm-charts/searchqna/README.md
@@ -20,7 +20,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update searchqna
 export MODELDIR="/mnt/opea-models"
 export MODEL="Intel/neural-chat-7b-v3-3"

--- a/helm-charts/txt2img/README.md
+++ b/helm-charts/txt2img/README.md
@@ -8,7 +8,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update txt2img
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"

--- a/helm-charts/visualqna/README.md
+++ b/helm-charts/visualqna/README.md
@@ -11,7 +11,7 @@ To install the chart, run the following:
 
 ```console
 cd GenAIInfra/helm-charts/
-./update_dependency.sh
+scripts/update_dependency.sh
 helm dependency update visualqna
 export HFTOKEN="insert-your-huggingface-token-here"
 export MODELDIR="/mnt/opea-models"


### PR DESCRIPTION
## Description

Move current `helm-charts/*.sh` scripts to new `helm-charts/scripts/` subdir.  Remove variable name inconsistency for that dir.

Done in preparation for future PRs that add more Helm chart helper scripts.

## Issues

`n/a`.

## Type of change

- [x] Enhancement

## Dependencies

`n/a`.

## Tests

Manually verified that all paths to these scripts have been updated accordingly:
```
scripts=$(ls helm-charts/scripts/)
for i in $scripts; do echo $i:; git grep $i; echo; done
```

## Next steps

Couple of docs in other repos reference `update_dependency.sh`, but that's all.  Those can be updated after this PR is in.

GenAIExamples:
```
DocSum/kubernetes/helm/README.md:./update_dependency.sh
DocSum/kubernetes/helm/README.md:./update_dependency.sh
```
docs:
```
tutorial/ChatQnA/deploy/k8s_getting_started.md:- A script called **./update_dependency.sh** is provided which is used to update chart dependencies, ensuring all nested charts are at their latest versions.
tutorial/ChatQnA/deploy/k8s_helm.md:./update_dependency.sh
```
