### PR TITLE
Fixed a typo in example command in README.md

### DIFF
--- a/kubeai/README.md
+++ b/kubeai/README.md
@@ -121,7 +121,7 @@ kubectl port-forward svc/kubeai -n kubeai 8000:80
 Query the models available:
 
 ```
-curl localhost:8000/opeanai/v1/models
+curl localhost:8000/openai/v1/models
 ```
 
 Depending on your configuration you should have something like this as an answer to the above command.


### PR DESCRIPTION
## Description

Fixed a typo in example command in README.md

- Typo fix in documentation

