### PR TITLE
Extend CI scripts to test for external LLM endpoints

### DIFF
--- a/.github/workflows/_helm-e2e.yaml
+++ b/.github/workflows/_helm-e2e.yaml
@@ -102,6 +102,13 @@ jobs:
           HFTOKEN: ${{ secrets.HF_TOKEN }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           FINANCIAL_DATASETS_API_KEY: ${{ secrets.FINANCIAL_DATASETS_API_KEY }}
+          # External LLM configuration for external-llm-values.yaml testing
+          LLM_SERVER_HOST_IP: ${{ secrets.LLM_SERVER_HOST_IP }}
+          LLM_SERVICE_HOST_IP: ${{ secrets.LLM_SERVER_HOST_IP }}
+          LLM_MODEL: ${{ secrets.LLM_MODEL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          LLM_SERVER_PORT: ${{ secrets.LLM_SERVER_PORT }}
+          LLM_SERVICE_PORT: ${{ secrets.LLM_SERVER_PORT }}
         run: |
           set -x
           USER_ID=$(whoami)
@@ -127,6 +134,40 @@ jobs:
                 ROLLOUT_TIMEOUT_SECONDS=900s
             fi
           done
+          
+          # Prepare external LLM arguments for external-llm-values.yaml files
+          external_llm_args=""
+          if [[ "${value_file}" == *"external-llm"* ]]; then
+            # Chart-specific mapping for environment variables (use LLM_SERVER_HOST_IP for all)
+            if [[ "${{ env.CHART_NAME }}" == "chatqna" ]]; then
+              if [[ -n "${{ env.LLM_SERVER_HOST_IP }}" ]]; then
+                external_llm_args="$external_llm_args --set externalLLM.LLM_SERVER_HOST_IP=${{ env.LLM_SERVER_HOST_IP }}"
+              fi
+              if [[ -n "${{ env.LLM_SERVER_PORT }}" ]]; then
+                external_llm_args="$external_llm_args --set externalLLM.LLM_SERVER_PORT=${{ env.LLM_SERVER_PORT }}"
+              fi
+            else
+              # DocSum/CodeGen use LLM_SERVICE_HOST_IP but we map from LLM_SERVER_HOST_IP
+              if [[ -n "${{ env.LLM_SERVER_HOST_IP }}" ]]; then
+                external_llm_args="$external_llm_args --set externalLLM.LLM_SERVICE_HOST_IP=${{ env.LLM_SERVER_HOST_IP }}"
+              fi
+              if [[ -n "${{ env.LLM_SERVER_PORT }}" ]]; then
+                external_llm_args="$external_llm_args --set externalLLM.LLM_SERVICE_PORT=${{ env.LLM_SERVER_PORT }}"
+              fi
+            fi
+            if [[ -n "${{ env.LLM_MODEL }}" ]]; then
+              external_llm_args="$external_llm_args --set externalLLM.LLM_MODEL=${{ env.LLM_MODEL }}"
+              # CodeGen also needs LLM_MODEL_ID
+              if [[ "${{ env.CHART_NAME }}" == "codegen" ]]; then
+                external_llm_args="$external_llm_args --set externalLLM.LLM_MODEL_ID=${{ env.LLM_MODEL }}"
+              fi
+            fi
+            if [[ -n "${{ env.OPENAI_API_KEY }}" ]]; then
+              external_llm_args="$external_llm_args --set externalLLM.OPENAI_API_KEY=${{ env.OPENAI_API_KEY }}"
+            fi
+            echo "External LLM configuration detected for ${{ env.CHART_NAME }}, adding arguments: $external_llm_args"
+          fi
+          
           if ! helm install --create-namespace --namespace $NAMESPACE --wait \
               --timeout "$ROLLOUT_TIMEOUT_SECONDS" \
               --set GOOGLE_API_KEY=${{ env.GOOGLE_API_KEY }} \
@@ -139,6 +180,7 @@ jobs:
               --set research-agent.FINANCIAL_DATASETS_API_KEY=${{ env.FINANCIAL_DATASETS_API_KEY }} \
               --set global.HUGGINGFACEHUB_API_TOKEN=${{ env.HFTOKEN }} \
               --set global.modelUseHostPath=${CHART_MOUNT} \
+              ${external_llm_args} \
               --values ${{ env.CHART_FOLDER }}/${value_file} \
               $RELEASE_NAME ${{ env.CHART_FOLDER }} ; then
             echo "Failed to install chart ${{ inputs.workload }}"

--- a/.github/workflows/_helm-e2e.yaml
+++ b/.github/workflows/_helm-e2e.yaml
@@ -134,7 +134,7 @@ jobs:
                 ROLLOUT_TIMEOUT_SECONDS=900s
             fi
           done
-          
+
           # Prepare external LLM arguments for external-llm-values.yaml files
           external_llm_args=""
           if [[ "${value_file}" == *"external-llm"* ]]; then
@@ -167,7 +167,7 @@ jobs:
             fi
             echo "External LLM configuration detected for ${{ env.CHART_NAME }}, adding arguments: $external_llm_args"
           fi
-          
+
           if ! helm install --create-namespace --namespace $NAMESPACE --wait \
               --timeout "$ROLLOUT_TIMEOUT_SECONDS" \
               --set GOOGLE_API_KEY=${{ env.GOOGLE_API_KEY }} \


### PR DESCRIPTION
## Description

This PR extends the CI scripts to support testing with external LLM endpoints. The changes add configuration for external LLM services in the Helm E2E workflow, allowing charts with external-llm-values.yaml files to be tested against external LLM providers. The implementation includes environment variable mapping for different chart types (ChatQnA, DocSum, CodeGen etc) and supports configurable LLM server hosts, ports, models, and API keys.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

No new 3rd party dependencies introduced.

## Tests

Describe the tests that you ran to verify your changes.
The changes extend existing Helm E2E tests to support external LLM endpoint testing. Charts with external-llm-values.yaml files will now be tested with the configured external LLM services using the appropriate environment variables and Helm chart arguments.