### PR TITLE
Remove extra "..." continuations from docs

### DIFF
--- a/helm-charts/common/data-prep/README.md
+++ b/helm-charts/common/data-prep/README.md
@@ -65,17 +65,17 @@ done
 
 # On K8s master node, run the following command:
 # Install using Helm with the following additional parameters:
-helm install ... ... --set global.offline=true,global.modelUseHostPath=${MODELDIR}
+helm install ... --set global.offline=true,global.modelUseHostPath=${MODELDIR}
 ```
 
 Assuming we share the offline data on cluster level using a persistent volume (PV), first we need to create the persistent volume claim (PVC) with name `opea-model-pvc` to store the model data.
 
 ```
 # Download model data at the root directory of the corresponding PV
-# ... ...
+# ...
 # Install using Helm with the following additional parameters:
 # export MODELPVC=opea-model-pvc
-# helm install ... ... --set global.offline=true,global.modelUsePVC=${MOELPVC}
+# helm install ... --set global.offline=true,global.modelUsePVC=${MOELPVC}
 ```
 
 ## Verify

--- a/helm-charts/common/gpt-sovits/README.md
+++ b/helm-charts/common/gpt-sovits/README.md
@@ -27,17 +27,17 @@ export MODEL_DIR=/mnt/opea-models
 huggingface-cli download --local-dir-use-symlinks False --local-dir "${MODEL_DIR}/lj1995/GPT-SoVITS" lj1995/GPT-SoVITS
 # On K8s master node, run the following command:
 # Install using Helm with the following additional parameters:
-helm install ... ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
+helm install ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
 ```
 
 Assuming we share the offline data on cluster level using a persistent volume (PV), first we need to create the persistent volume claim (PVC) with name `opea-model-pvc` to store the model data.
 
 ```
 # Download model openai/whisper-small at the root directory of the corresponding PV
-# ... ...
+# ...
 # Install using Helm with the following additional parameters:
 # export MODEL_PVC=opea-model-pvc
-# helm install ... ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
+# helm install ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
 ```
 
 ## Verify

--- a/helm-charts/common/llm-uservice/README.md
+++ b/helm-charts/common/llm-uservice/README.md
@@ -80,7 +80,7 @@ huggingface-cli download --cache-dir "${MODEL_DIR}" ${LLM_MODEL_ID}
 
 # On K8s master node, run the following command:
 # Install using Helm with the following additional parameters:
-helm install ... ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
+helm install ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
 
 ```
 
@@ -88,10 +88,10 @@ Assuming we share the offline data on cluster level using a persistent volume (P
 
 ```
 # Download model data at the root directory of the corresponding PV
-# ... ...
+# ...
 # Install using Helm with the following additional parameters:
 # export MODEL_PVC=opea-model-pvc
-# helm install ... ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
+# helm install ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
 ```
 
 There is no special step or setting needed to run `llm-textgen` or `llm-faqgen` microservice in an air gapped environment.

--- a/helm-charts/common/speecht5/README.md
+++ b/helm-charts/common/speecht5/README.md
@@ -27,17 +27,17 @@ huggingface-cli download --cache-dir "${MODEL_DIR}" microsoft/speecht5_tts
 huggingface-cli download --cache-dir "${MODEL_DIR}" microsoft/speecht5_hifigan
 # On K8s master node, run the following command:
 # Install using Helm with the following additional parameters:
-helm install ... ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
+helm install ... --set global.offline=true,global.modelUseHostPath=${MODEL_DIR}
 ```
 
 Assuming we share the offline data on cluster level using a persistent volume (PV), first we need to create the persistent volume claim (PVC) with name `opea-model-pvc` to store the model data.
 
 ```
 # Download model openai/whisper-small at the root directory of the corresponding PV
-# ... ...
+# ...
 # Install using Helm with the following additional parameters:
 # export MODEL_PVC=opea-model-pvc
-# helm install ... ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
+# helm install ... --set global.offline=true,global.modelUsePVC=${MODEL_PVC}
 ```
 
 ## Verify


### PR DESCRIPTION
## Description

Remove extra "..." continuations from docs.

(Single "..." continuation is slightly more readable than multiple of them, and consistent with other docs.)

## Issues

`n/a`.

## Type of change

- [x] Enhancement (docs)

## Dependencies

`n/a`.

## Tests

CI.